### PR TITLE
Add netcdf provider

### DIFF
--- a/python/ngen_conf/src/ngen/config/configurations.py
+++ b/python/ngen_conf/src/ngen/config/configurations.py
@@ -13,13 +13,13 @@ class Forcing(BaseModel, smart_union=True):
         """Enumeration of the supported NGEN forcing provider strings
         """
         CSV = "CsvPerFeature"
-        NetCDF = "FIXME"
+        NetCDF = "NetCDF"
     
     #required
     file_pattern: Optional[Union[FilePath, str]]
     path: Union[DirectoryPath, FilePath, str]
     #reasonable? default
-    provider: Provider = Field(Provider.CSV, const=True)
+    provider: Provider = Field(Provider.CSV)
 
 class Time(BaseModel):
     """Model for ngen time configuraiton components

--- a/python/ngen_conf/tests/conftest.py
+++ b/python/ngen_conf/tests/conftest.py
@@ -14,10 +14,17 @@ _workdir=Path(__file__).parent
 Fixtures for setting up various ngen-conf components for testing
 """
 @pytest.fixture
-def forcing():
+def forcing(request):
+    which = request.param
+    if which == "netcdf":
+        provider = Forcing.Provider.NetCDF
+    else:
+        #default to csv
+        provider = Forcing.Provider.CSV
+    print(provider)
     forcing = _workdir.joinpath("data/forcing/")
     #Share forcing for all formulations
-    return Forcing(file_pattern=".*{{id}}.*.csv", path=forcing, provider=Forcing.Provider.CSV)
+    return Forcing(file_pattern=".*{{id}}.*.csv", path=forcing, provider=provider)
 
 @pytest.fixture
 def time():

--- a/python/ngen_conf/tests/test_cfe.py
+++ b/python/ngen_conf/tests/test_cfe.py
@@ -14,6 +14,8 @@ def test_name_map_override(cfe_params):
     cfe = CFE(**cfe_params)
     assert cfe.name_map["atmosphere_water__liquid_equivalent_precipitation_rate"] == 'RAINRATE'
 
+
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
 def test_cfe_formulation(cfe_params, forcing):
     cfe = CFE(**cfe_params)
     f = {"params":cfe, "name":"bmi_c"}

--- a/python/ngen_conf/tests/test_lstm.py
+++ b/python/ngen_conf/tests/test_lstm.py
@@ -14,6 +14,7 @@ def test_no_lib(lstm_params):
     lstm = LSTM(**lstm_params)
     assert "library" not in lstm.dict().keys()
 
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
 def test_lstm_formulation(lstm_params, forcing):
     lstm = LSTM(**lstm_params)
     f = {"params":lstm, "name":"bmi_python"}

--- a/python/ngen_conf/tests/test_realization.py
+++ b/python/ngen_conf/tests/test_realization.py
@@ -15,7 +15,7 @@ def test_ngen_global_realization(forcing, time, cfe):
     # This can essentially be used at this point for an ngen integration test
     # by writing the realization and then running `ngen` with it...
     # with open("test_realization.json", 'w') as fp:
-    #     fp.write( g.json(by_alias=True, exclude_none=True, indent=4))
+    #     fp.write( g.json(by_alias=True, exclude_none=True, indent=
 
 def test_ngen_global_multi_realization(forcing, time, multi):
     f = Formulation(name=multi.name, params=multi)

--- a/python/ngen_conf/tests/test_realization.py
+++ b/python/ngen_conf/tests/test_realization.py
@@ -4,10 +4,12 @@ from ngen.config.formulation import Formulation
 
 import json
 
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
 def test_realization(forcing, time, cfe):
     f = Formulation(name=cfe.name, params=cfe)
     r = Realization(forcing=forcing, formulations=[f])
 
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
 def test_ngen_global_realization(forcing, time, cfe):
     f = Formulation(name=cfe.name, params=cfe)
     r = Realization(formulations=[f], forcing=forcing)
@@ -15,8 +17,9 @@ def test_ngen_global_realization(forcing, time, cfe):
     # This can essentially be used at this point for an ngen integration test
     # by writing the realization and then running `ngen` with it...
     # with open("test_realization.json", 'w') as fp:
-    #     fp.write( g.json(by_alias=True, exclude_none=True, indent=
+    #     fp.write( g.json(by_alias=True, exclude_none=True, indent=4))
 
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
 def test_ngen_global_multi_realization(forcing, time, multi):
     f = Formulation(name=multi.name, params=multi)
     r = Realization(formulations=[f], forcing=forcing)

--- a/python/ngen_conf/tests/test_topmod.py
+++ b/python/ngen_conf/tests/test_topmod.py
@@ -14,6 +14,7 @@ def test_name_map_override(topmod_params):
     topmod = Topmod(**topmod_params)
     assert topmod.name_map["atmosphere_water__liquid_equivalent_precipitation_rate"] == 'RAINRATE'
 
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
 def test_topmodformulation(topmod_params, forcing):
     topmod = Topmod(**topmod_params)
     f = {"params":topmod, "name":"bmi_c"}


### PR DESCRIPTION
Closes #22.

## Additions

- NetCDF forcing provider type

## Removals

-

## Changes

- Forcing type of a realization is no longer const

## Testing

1. All unit tests using Forcing fixture were paramterized and now run with both netcdf and csv provided types

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
