### PR TITLE
Add PathPair and PathPairCollection types

### DIFF
--- a/python/ngen_conf/setup.cfg
+++ b/python/ngen_conf/setup.cfg
@@ -31,6 +31,7 @@ package_dir =
 install_requires =
     pydantic<2
     geojson_pydantic
+    typing_extensions
 python_requires = >=3.7
 include_package_data = True
 

--- a/python/ngen_conf/src/ngen/config/path_pair/__init__.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/__init__.py
@@ -1,0 +1,10 @@
+from .path_pair import (
+    PathPair,
+    PathPairCollection,
+    PosixPathPair,
+    WindowsPathPair,
+    PosixPathPairCollection,
+    WindowsPathPairCollection,
+)
+
+from .common import pydantic_serializer, pydantic_deserializer

--- a/python/ngen_conf/src/ngen/config/path_pair/_abc_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_abc_mixins.py
@@ -1,0 +1,74 @@
+from abc import ABC, abstractmethod
+
+from typing import Generic, Iterable, Optional
+from typing_extensions import Self
+
+from .typing import StrPath, T
+
+
+class AbstractPathPairMixin(ABC, Generic[T]):
+    @property
+    @abstractmethod
+    def inner(self) -> Optional[T]:
+        ...
+
+    @abstractmethod
+    def with_path(self, *args: StrPath) -> Self:
+        ...
+
+    @abstractmethod
+    def serialize(self) -> Optional[bytes]:
+        ...
+
+    @abstractmethod
+    def deserialize(self, data: bytes) -> bool:
+        ...
+
+    @abstractmethod
+    def read(self) -> bool:
+        ...
+
+    @abstractmethod
+    def write(self) -> bool:
+        ...
+
+
+class AbstractPathPairCollectionMixin(ABC, Generic[T]):
+    @property
+    @abstractmethod
+    def pattern(self) -> str:
+        ...
+
+    @property
+    @abstractmethod
+    def inner(self) -> Iterable[T]:
+        ...
+
+    @property
+    @abstractmethod
+    def inner_pair(
+        self,
+    ) -> Iterable[AbstractPathPairMixin[T]]:
+        ...
+
+    @abstractmethod
+    def with_pattern(self, pattern: str) -> Self:
+        ...
+
+    @abstractmethod
+    def serialize(self) -> Iterable[bytes]:
+        ...
+
+    @abstractmethod
+    def deserialize(
+        self, data: Iterable[bytes], *, paths: Optional[Iterable[StrPath]] = None
+    ) -> bool:
+        ...
+
+    @abstractmethod
+    def read(self) -> bool:
+        ...
+
+    @abstractmethod
+    def write(self) -> bool:
+        ...

--- a/python/ngen_conf/src/ngen/config/path_pair/_abc_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_abc_mixins.py
@@ -7,68 +7,187 @@ from .typing import StrPath, T
 
 
 class AbstractPathPairMixin(ABC, Generic[T]):
+    """
+    API that should be mixed in with a `pathlib.Path` subclass to expose methods for reading,
+    writing, and de/serializing to and from a wrapped inner type `T`.
+
+    Additionally, this abstraction serves to improve _factory classes_ type hints by denoting that
+    all subtypes of the factory implement the API. This follows suit with the factory class
+    `pathlib.Path` that returns an OS dependent subtype (e.g. `pathlib.WindowsPath` or
+    `pathlib.PosixPath`) that implements `pathlib.Path`'s API.
+    """
+
     @property
     @abstractmethod
     def inner(self) -> Optional[T]:
-        ...
+        """Return the inner object if it exists."""
 
     @abstractmethod
     def with_path(self, *args: StrPath) -> Self:
-        ...
+        """
+        Return a _new_ `PathPair` instance with the same reader, writer, and de/serializer as the
+        current instance but with a different path.
+
+        Returns
+        -------
+        Self
+        """
 
     @abstractmethod
     def serialize(self) -> Optional[bytes]:
-        ...
+        """
+        If the inner `T` exists, return a serialized version.
+
+        Returns
+        -------
+        Optional[bytes]
+        """
 
     @abstractmethod
     def deserialize(self, data: bytes) -> bool:
-        ...
+        """
+        Try to deserialize the provided bytes into an inner encapsulated `T`. Throw if
+        deserialization fails. If an inner `T` already exists and it deserializes correctly,
+        replace the inner `T` with the new instance. Return `True` if success and `False` if there
+        is not enough information to attempt deserialization.
+
+        Parameters
+        ----------
+        data : bytes
+
+        Returns
+        -------
+        bool
+            True if successful, False if there is not enough information to attempt deserialization.
+        """
 
     @abstractmethod
-    def read(self) -> bool:
-        ...
+    def read(self):
+        """
+        Try to read the current path and deserialize into an inner encapsulated `T`. If an inner `T`
+        already exists and it deserializes correctly, replace the inner `T` with the new instance.
+        Throw if deserialization or reading fails.  Return `True` if success and `False` if there is
+        not enough information to attempt deserialization.
+
+        Returns
+        -------
+        bool
+            True if successful, False if there is not enough information to attempt deserialization.
+        """
 
     @abstractmethod
     def write(self) -> bool:
-        ...
+        """
+        Try to serialize the inner `T` and write to the current path. Throw if serialization or
+        writing fails. Return `True` if is success and `False` if there is not enough
+        information to attempt deserialization.
+
+        Returns
+        -------
+        bool
+            True if successful, False if there is not enough information to attempt serialization.
+        """
 
 
 class AbstractPathPairCollectionMixin(ABC, Generic[T]):
+    """
+    API that should be mixed in with a `pathlib.Path` subclass to expose methods for reading,
+    writing, and de/serializing to and from a collection of wrapped inner `AbstractPathPairMixin[T]`s.
+    """
+
     @property
     @abstractmethod
     def pattern(self) -> str:
-        ...
+        """
+        String that should be replaced within the path to build the collection of files.
+
+        Example:
+            path: "/domain_files/domain_{id}.geojson"
+            pattern: "{id}"
+        """
 
     @property
     @abstractmethod
     def inner(self) -> Iterable[T]:
-        ...
+        """
+        An iterable that returns inner `T`s
+        """
 
     @property
     @abstractmethod
     def inner_pair(
         self,
     ) -> Iterable[AbstractPathPairMixin[T]]:
-        ...
+        """
+        An iterable that returns inner `AbstractPathPairMixin[T]`s
+        """
 
     @abstractmethod
     def with_pattern(self, pattern: str) -> Self:
-        ...
+        """
+        Return a _new_ `PathPairCollection` instance with the same reader, writer, and de/serializer
+        as the current instance but with a different pattern.
+
+        Returns
+        -------
+        Self
+        """
 
     @abstractmethod
     def serialize(self) -> Iterable[bytes]:
-        ...
+        """
+        Return an iterable of serialized inner `T`'s
+        """
 
     @abstractmethod
     def deserialize(
         self, data: Iterable[bytes], *, paths: Optional[Iterable[StrPath]] = None
     ) -> bool:
-        ...
+        """
+        Deserialize iterable of bytes into `T`'s and wrap each `T` as a `PathPair[T]`. Replace
+        `self`'s inner collection with the deserialized collection. Return `True` if success and
+        `False` if there is not enough information to attempt deserialization.
+
+        If `paths` is None, the inner `PathPair[T]`'s have `self`'s path.
+
+        If `paths` is provided, each _i_th inner `PathPair[T]` will have the path at the _i_th
+        iteration. Likewise, `data` and `paths` must iterate _k_ times.
+
+        Parameters
+        ----------
+        data : Iterable[bytes]
+        paths : Optional[Iterable[StrPath]], optional
+            If provided, inner _i_th `PathPair[T]`s will have the associated _i_th path, by default None
+
+        Returns
+        -------
+        bool
+            True if successful, False if there is not enough information to attempt deserialization
+        """
 
     @abstractmethod
     def read(self) -> bool:
-        ...
+        """
+        Try to read and deserialize files on the current path that follow the current prefix.
+        Throw if deserialization or reading fails. If an inner collection already exists and read
+        is successful, the previous collection is *replaced*. Return `True` if success and `False`
+        if there is not enough information to attempt deserialization.
+
+        Returns
+        -------
+        bool
+            True if successful, False if there is not enough information to attempt reading or deserialization
+        """
 
     @abstractmethod
     def write(self) -> bool:
-        ...
+        """
+        Try to serialize and write the inner collection of `PathPair[T]`s to their pathname. Throw
+        if serialization or writing fails. Does not ensure cleanup. Return `True` if is success and
+        `False` if there is not enough information to attempt serialization or writing.
+
+        Returns
+        -------
+        bool
+            True if is successful, False if there is not enough information to attempt serialization or writing
+        """

--- a/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
@@ -96,7 +96,7 @@ class PathPairCollectionMixin(PathPairMixin[T]):
     @property
     def inner(self) -> Iterable[T]:
         for item in self._inner:
-            yield item
+            yield item.inner
 
     @property
     def inner_pair(

--- a/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
@@ -25,7 +25,7 @@ class PathPairMixin(Generic[T]):
         return self._inner
 
     def with_path(self, *args: StrPath) -> Self:
-        return self.from_object(
+        return self.with_object(
             self.inner,
             path=Path(*args),
             reader=self._reader,
@@ -149,7 +149,7 @@ class PathPairCollectionMixin(PathPairMixin[T]):
         if paths is None:
             deserialized_path = Path(self)
             deserialized = [
-                PathPair.from_object(
+                PathPair.with_object(
                     self._deserializer(item),
                     path=deserialized_path,
                     reader=self._reader,
@@ -168,7 +168,7 @@ class PathPairCollectionMixin(PathPairMixin[T]):
                 if item == ValueError or path == ValueError:
                     raise ValueError(error_message)
 
-                path_pair = PathPair.from_object(
+                path_pair = PathPair.with_object(
                     self._deserializer(item),
                     path=path,
                     reader=self._reader,

--- a/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
@@ -1,0 +1,182 @@
+from pathlib import Path
+
+from typing import Generic, Optional, Union, Iterator, Iterable, TYPE_CHECKING
+from typing_extensions import Self
+from .typing import StrPath, T
+
+if TYPE_CHECKING:
+    from .path_pair import PosixPathPair, WindowsPathPair, PathPairCollection
+
+
+class PathPairMixin(Generic[T]):
+    def __truediv__(self, key: StrPath) -> Self:
+        return self.with_path(Path(self).joinpath(Path(key)))
+
+    def __rtruediv__(self, key: StrPath) -> Self:
+        return self.with_path(Path(key).joinpath(self))
+
+    @property
+    def parent(self) -> Path:
+        return Path(self).parent
+
+    @property
+    def inner(self) -> Optional[T]:
+        return self._inner
+
+    def with_path(self, *args: StrPath) -> Self:
+        return self.from_object(
+            self.inner,
+            path=Path(*args),
+            reader=self._reader,
+            writer=self._writer,
+            serializer=self._serializer,
+            deserializer=self._deserializer,
+        )
+
+    def serialize(self) -> Optional[bytes]:
+        if self._serializer is None or self._inner is None:
+            return None
+
+        return self._serializer(self.inner)
+
+    def deserialize(self, data: bytes) -> bool:
+        if self._deserializer is None or self._reader is None:
+            return False
+
+        self._inner = self._deserializer(data)
+        return True
+
+    def read(self) -> bool:
+        return self.deserialize(self._reader(self))
+
+    def write(self) -> bool:
+        if self._serializer is None or self._inner is None:
+            return False
+
+        self._writer(self, self.serialize())
+        return True
+
+
+class PathPairCollectionMixin(PathPairMixin[T]):
+    def __truediv__(self, key: StrPath) -> Self:
+        # noop
+        return self
+
+    def __rtruediv__(self, key: StrPath) -> Self:
+        # avoid circular import
+        from .path_pair import PathPairCollection
+
+        inner = [key / item for item in self._inner]
+        new_path = Path(key).joinpath(self)
+        return PathPairCollection(
+            new_path,
+            pattern=self._pattern,
+            inner=inner,
+            reader=self._reader,
+            writer=self._writer,
+            serializer=self._serializer,
+            deserializer=self._deserializer,
+        )
+
+    def _get_filenames(self) -> Iterator[Path]:
+        prefix, _, suffix = self.name.partition(self.pattern)
+        glob_term = f"{prefix}*{suffix}"
+        yield from self.parent.glob(glob_term)
+
+    @property
+    def pattern(self) -> str:
+        return self._pattern
+
+    @property
+    def inner(self) -> Iterable[T]:
+        for item in self._inner:
+            yield item
+
+    @property
+    def inner_pair(
+        self,
+    ) -> Union[Iterator["PosixPathPair[T]"], Iterable["WindowsPathPair[T]"]]:
+        for item in self._inner:
+            yield item
+
+    def with_path(self, *args: StrPath) -> Self:
+        # noop
+        return self
+
+    def with_pattern(self, pattern: str) -> "PathPairCollection[T]":
+        # avoid circular import
+        from .path_pair import PathPairCollection
+
+        return PathPairCollection[T](
+            self,
+            pattern=pattern,
+            inner=self._inner,
+            reader=self._reader,
+            writer=self._writer,
+            serializer=self._serializer,
+            deserializer=self._deserializer,
+        )
+
+    def serialize(self) -> Iterable[bytes]:
+        if self._serializer is None or self._inner is None:
+            return None
+
+        for item in self.inner:
+            yield self._serializer(item)
+
+    def deserialize(self, data: Iterable[bytes]) -> bool:
+        # avoid circular import
+        from .path_pair import PathPair
+
+        if self._deserializer is None or self._reader is None:
+            return False
+
+        deserialized = [
+            PathPair.from_object(
+                self._deserializer(self._reader(item)),
+                path="",
+                reader=self._reader,
+                writer=self._writer,
+                serializer=self._serializer,
+                deserializer=self._deserializer,
+            )
+            for item in data
+        ]
+
+        self._inner = deserialized
+        return True
+
+    def read(self) -> bool:
+        # avoid circular import
+        from .path_pair import PathPair
+
+        if self._deserializer is None or self._reader is None:
+            return False
+
+        deserialized = [
+            PathPair.from_object(
+                self._deserializer(self._reader(file)),
+                path=file,
+                reader=self._reader,
+                writer=self._writer,
+                serializer=self._serializer,
+                deserializer=self._deserializer,
+            )
+            for file in self._get_filenames()
+        ]
+
+        self._inner = deserialized
+        return True
+
+    def write(self) -> bool:
+        if self._serializer is None or self._inner is None or self._writer is None:
+            return False
+
+        for item in self._inner:
+            self._writer(item, item.serialize())
+
+        return True
+
+    def unlink(self, missing_ok: bool = False):
+        for item in self._inner:
+            item.unlink(missing_ok=missing_ok)

--- a/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
@@ -83,6 +83,11 @@ class PathPairCollectionMixin(PathPairMixin[T]):
         glob_term = f"{prefix}*{suffix}"
         yield from self.parent.glob(glob_term)
 
+    def with_path(self, *args: StrPath) -> Self:
+        # TODO: this seems like the _right_ thing to do here, but this could change in the future.
+        # noop
+        return self
+
     @property
     def pattern(self) -> str:
         return self._pattern

--- a/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_mixins.py
@@ -2,6 +2,7 @@ from itertools import zip_longest
 from pathlib import Path
 
 from ._abc_mixins import AbstractPathPairMixin, AbstractPathPairCollectionMixin
+from ._utils import path_unlink_37
 
 from typing import Optional, Iterable
 from typing_extensions import Self
@@ -55,6 +56,9 @@ class PathPairMixin(AbstractPathPairMixin[T]):
 
         self._writer(self, self.serialize())
         return True
+
+    def unlink(self, missing_ok: bool = False):
+        path_unlink_37(Path(self), missing_ok=missing_ok)
 
 
 class PathPairCollectionMixin(AbstractPathPairCollectionMixin[T]):

--- a/python/ngen_conf/src/ngen/config/path_pair/_utils.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_utils.py
@@ -8,6 +8,7 @@ def path_unlink_37(p: Path, missing_ok: bool):
     # TODO: remove once we drop 3.7 support
     if sys.version_info >= (3, 8):
         p.unlink(missing_ok=missing_ok)
+        return
     if missing_ok and not p.exists():
         return
     p.unlink()

--- a/python/ngen_conf/src/ngen/config/path_pair/_utils.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_utils.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+
+def path_unlink_37(p: Path, missing_ok: bool):
+    # see: https://docs.python.org/3.8/library/pathlib.html#pathlib.Path.unlink
+    # > _Changed_ in version 3.8: The _missing_ok_ parameter was added.
+    # TODO: remove once we drop 3.7 support
+    if sys.version_info >= (3, 8):
+        p.unlink(missing_ok=missing_ok)
+    if missing_ok and not p.exists():
+        return
+    p.unlink()

--- a/python/ngen_conf/src/ngen/config/path_pair/common.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/common.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+from pathlib import Path
+
+from .protocol import Deserializer
+
+from typing import Type, TypeVar
+
+M = TypeVar("M", bound=BaseModel)
+
+
+def path_reader(p: Path) -> bytes:
+    return p.read_bytes()
+
+
+def path_writer(p: Path, data: bytes) -> None:
+    p.write_bytes(data)
+
+
+def pydantic_serializer(o: BaseModel) -> bytes:
+    return o.json(by_alias=True).encode()
+
+
+def pydantic_deserializer(m: Type[M]) -> Deserializer[M]:
+    def deserialize(data: bytes) -> M:
+        return m.parse_raw(data)
+
+    return deserialize

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -1,0 +1,213 @@
+import os
+from pathlib import Path, PosixPath, WindowsPath
+
+from .protocol import Reader, Writer, Serializer, Deserializer
+from .common import path_reader, path_writer
+from ._mixins import PathPairMixin, PathPairCollectionMixin
+
+from typing import (
+    Any,
+    Generic,
+    Optional,
+    Union,
+    List,
+)
+from .typing import StrPath, T
+
+
+class PathPair(Path, Generic[T]):
+    def __new__(
+        cls,
+        *args: StrPath,
+        inner: Optional[T] = None,
+        reader: Reader = path_reader,
+        writer: Writer = path_writer,
+        serializer: Optional[Serializer[T]] = None,
+        deserializer: Optional[Deserializer[T]] = None,
+        **kwargs: Any,
+    ) -> Union["WindowsPathPair[T]", "PosixPathPair[T]"]:
+        cls = WindowsPathPair[T] if os.name == "nt" else PosixPathPair[T]
+        self: Union[WindowsPathPair[T], PosixPathPair[T]] = Path.__new__(
+            cls, *args, **kwargs
+        )
+        self._inner = inner
+        self._serializer = serializer
+        self._deserializer = deserializer
+        self._reader = reader
+        self._writer = writer
+        return self
+
+    @classmethod
+    def from_object(
+        cls,
+        o: T,
+        *,
+        path: StrPath = "",
+        reader: Optional[Reader] = path_reader,
+        writer: Optional[Writer] = path_writer,
+        serializer: Optional[Serializer[T]] = None,
+        deserializer: Optional[Deserializer[T]] = None,
+    ) -> Union["PosixPathPair[T]", "WindowsPathPair[T]"]:
+        return cls(
+            Path(path),
+            inner=o,
+            reader=reader,
+            writer=writer,
+            serializer=serializer,
+            deserializer=deserializer,
+        )
+
+
+class PathPairCollection(Path, Generic[T]):
+    def __new__(
+        cls,
+        *args: StrPath,
+        pattern: str,
+        inner: Optional[List["PosixPathPair[T]"]] = None,
+        reader: Reader = path_reader,
+        writer: Writer = path_writer,
+        serializer: Optional[Serializer[T]] = None,
+        deserializer: Optional[Deserializer[T]] = None,
+        **kwargs: Any,
+    ) -> Union["WindowsPathPairCollection[T]", "PosixPathPairCollection[T]"]:
+        cls = (
+            WindowsPathPairCollection[T]
+            if os.name == "nt"
+            else PosixPathPairCollection[T]
+        )
+
+        template_str = Path(*args)
+
+        if inner is None:
+            inner = []
+
+        prefix, _, suffix = template_str.name.partition(pattern)
+        for item in inner:
+            if PathPairCollection._get_id(item, prefix, suffix) == "":
+                raise ValueError(
+                    f"Filename not derived from template and pattern, {template_str.name!r} {pattern!r}: {item}"
+                )
+
+        self: Union[
+            WindowsPathPairCollection[T], PosixPathPairCollection[T]
+        ] = Path.__new__(
+            cls,
+            *args,
+            inner=inner,
+            reader=reader,
+            writer=writer,
+            serializer=serializer,
+            deserializer=deserializer,
+            **kwargs,
+        )
+        self._inner = inner
+        self._serializer = serializer
+        self._deserializer = deserializer
+        self._reader = reader
+        self._writer = writer
+        self._pattern = pattern
+        return self
+
+    @staticmethod
+    def _get_id(
+        p: "PosixPathPair[T]",
+        prefix: str,
+        suffix: str,
+    ) -> str:
+        assert prefix != "" and suffix != ""
+
+        return p.name[len(prefix) : -len(suffix)]
+
+    @classmethod
+    def cwd(cls) -> Path:
+        return Path.cwd()
+
+    @classmethod
+    def home(cls) -> Path:
+        return Path.home()
+
+    @classmethod
+    def from_objects(
+        cls,
+        o: List[T],
+        *,
+        path: Path,
+        pattern: str,
+        ids: List[str],
+        reader: Optional[Reader] = path_reader,
+        writer: Optional[Writer] = path_writer,
+        serializer: Optional[Serializer[T]] = None,
+        deserializer: Optional[Deserializer[T]] = None,
+    ) -> Union["PosixPathPairCollection[T]", "WindowsPathPairCollection[T]"]:
+        assert len(o) == len(ids)
+        prefix, _, suffix = path.name.partition(pattern)
+        assert prefix != "" and suffix != ""
+
+        pairs = []
+        for idx, item in enumerate(o):
+            fp = path.parent / f"{prefix}{ids[idx]}{suffix}"
+            pair = PathPair.from_object(
+                item,
+                path=fp,
+                reader=reader,
+                writer=writer,
+                serializer=serializer,
+                deserializer=deserializer,
+            )
+            pairs.append(pair)
+
+        return cls(
+            path,
+            pattern=pattern,
+            inner=pairs,
+            reader=reader,
+            writer=writer,
+            serializer=serializer,
+            deserializer=deserializer,
+        )
+
+
+class PosixPathPair(PathPairMixin[T], PathPair[T], PosixPath):
+    __slots__ = (
+        "_inner",  # Optional[T]
+        "_serializer",  # Serializer[T]
+        "_deserializer",  # Deserializer[T]
+        "_reader",  # Reader
+        "_writer",  # Writer
+    )
+
+
+class WindowsPathPair(PathPairMixin[T], PathPair[T], WindowsPath):
+    __slots__ = (
+        "_inner",  # Optional[T]
+        "_serializer",  # Serializer[T]
+        "_deserializer",  # Deserializer[T]
+        "_reader",  # Reader
+        "_writer",  # Writer
+    )
+
+
+class PosixPathPairCollection(
+    PathPairCollectionMixin[T], PathPairCollection[T], PosixPath
+):
+    __slots__ = (
+        "_inner",  # Union[List[ObjectPosixPathPair[T], List[ObjectWindowsPathPair[T]]]]
+        "_serializer",  # Serializer[T]
+        "_deserializer",  # Deserializer[T]
+        "_reader",  # Reader
+        "_writer",  # Writer
+        "_pattern",  # str
+    )
+
+
+class WindowsPathPairCollection(
+    PathPairCollectionMixin[T], PathPairCollection[T], WindowsPath
+):
+    __slots__ = (
+        "_inner",  # Union[List[ObjectPosixPathPair[T], List[ObjectWindowsPathPair[T]]]]
+        "_serializer",  # Serializer[T]
+        "_deserializer",  # Deserializer[T]
+        "_reader",  # Reader
+        "_writer",  # Writer
+        "_pattern",  # str
+    )

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -38,7 +38,7 @@ class PathPair(Path, Generic[T]):
         return self
 
     @classmethod
-    def from_object(
+    def with_object(
         cls,
         o: T,
         *,
@@ -127,7 +127,7 @@ class PathPairCollection(Path, Generic[T]):
         return Path.home()
 
     @classmethod
-    def from_objects(
+    def with_objects(
         cls,
         o: List[T],
         *,
@@ -146,7 +146,7 @@ class PathPairCollection(Path, Generic[T]):
         pairs = []
         for idx, item in enumerate(o):
             fp = path.parent / f"{prefix}{ids[idx]}{suffix}"
-            pair = PathPair.from_object(
+            pair = PathPair.with_object(
                 item,
                 path=fp,
                 reader=reader,

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -3,6 +3,7 @@ from pathlib import Path, PosixPath, WindowsPath
 
 from .protocol import Reader, Writer, Serializer, Deserializer
 from .common import path_reader, path_writer
+from ._abc_mixins import AbstractPathPairMixin, AbstractPathPairCollectionMixin
 from ._mixins import PathPairMixin, PathPairCollectionMixin
 
 from typing import (
@@ -15,7 +16,7 @@ from typing import (
 from .typing import StrPath, T
 
 
-class PathPair(Path, Generic[T]):
+class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
     """A `pathlib.Path` subclass that encapsulates some inner `T` and methods for reading, writing,
     and de/serializing to and from a `T`. Similarly to `pathlib.Path`, creating a `PathPair` will
     return a OS specific subclass (`PosixPathPair` or `WindowsPathPair`).
@@ -74,7 +75,10 @@ class PathPair(Path, Generic[T]):
         )
 
 
-class PathPairCollection(Path, Generic[T]):
+        return PathPair(value)
+
+
+class PathPairCollection(AbstractPathPairCollectionMixin[T], Path, Generic[T]):
     """A `pathlib.Path` subclass that encapsulates a collection of `T`'s and methods for reading,
     writing, and de/serializing to and from a the collection of `T`'s. This type enables treating a
     collection of paths, that follow some naming convention, as a single path object. Similarly to

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -16,6 +16,22 @@ from .typing import StrPath, T
 
 
 class PathPair(Path, Generic[T]):
+    """A `pathlib.Path` subclass that encapsulates some inner `T` and methods for reading, writing,
+    and de/serializing to and from a `T`. Similarly to `pathlib.Path`, creating a `PathPair` will
+    return a OS specific subclass (`PosixPathPair` or `WindowsPathPair`).
+
+    The default reader and writer implementations operate on disk. Alternative reader and writer
+    types can be provided assuming they following the `ngen.config.path_path.protocol` `Reader` and
+    `Writer` protocols (interfaces). This could, for example, enable reading and writing from the
+    network.
+
+    serializer's and deserializer's are type specific, and thus have no default. However,
+    `ngen.config.path_path.common` contains generic serializers and deserializer that may be of
+    interest (e.g. `pydantic_serializer` and `pydantic_deserializer`). Alternative serializer and
+    deserializer types can be provided assuming they follow the `ngen.config.path_path.protocol`
+    `Serializer` and `Deserializer` protocols (interfaces).
+    """
+
     def __new__(
         cls,
         *args: StrPath,
@@ -59,6 +75,24 @@ class PathPair(Path, Generic[T]):
 
 
 class PathPairCollection(Path, Generic[T]):
+    """A `pathlib.Path` subclass that encapsulates a collection of `T`'s and methods for reading,
+    writing, and de/serializing to and from a the collection of `T`'s. This type enables treating a
+    collection of paths, that follow some naming convention, as a single path object. Similarly to
+    `pathlib.Path`, creating a `PathPairCollection` will return a OS specific subclass
+    (`PosixPathPairCollection` or `WindowsPathPairCollection`).
+
+    The default reader and writer implementations operate on disk. Alternative reader and writer
+    types can be provided assuming they following the `ngen.config.path_path.protocol` `Reader` and
+    `Writer` protocols (interfaces). This could, for example, enable reading and writing from the
+    network.
+
+    serializer's and deserializer's are type specific, and thus have no default. However,
+    `ngen.config.path_path.common` contains generic serializers and deserializer that may be of
+    interest (e.g. `pydantic_serializer` and `pydantic_deserializer`). Alternative serializer and
+    deserializer types can be provided assuming they follow the `ngen.config.path_path.protocol`
+    `Serializer` and `Deserializer` protocols (interfaces).
+    """
+
     def __new__(
         cls,
         *args: StrPath,

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -17,14 +17,14 @@ class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
     return a OS specific subclass (`PosixPathPair` or `WindowsPathPair`).
 
     The default reader and writer implementations operate on disk. Alternative reader and writer
-    types can be provided assuming they following the `ngen.config.path_path.protocol` `Reader` and
+    types can be provided assuming they following the `ngen.config.path_pair.protocol` `Reader` and
     `Writer` protocols (interfaces). This could, for example, enable reading and writing from the
     network.
 
     serializer's and deserializer's are type specific, and thus have no default. However,
-    `ngen.config.path_path.common` contains generic serializers and deserializer that may be of
+    `ngen.config.path_pair.common` contains generic serializers and deserializer that may be of
     interest (e.g. `pydantic_serializer` and `pydantic_deserializer`). Alternative serializer and
-    deserializer types can be provided assuming they follow the `ngen.config.path_path.protocol`
+    deserializer types can be provided assuming they follow the `ngen.config.path_pair.protocol`
     `Serializer` and `Deserializer` protocols (interfaces).
     """
 
@@ -95,14 +95,14 @@ class PathPairCollection(AbstractPathPairCollectionMixin[T], Path, Generic[T]):
     (`PosixPathPairCollection` or `WindowsPathPairCollection`).
 
     The default reader and writer implementations operate on disk. Alternative reader and writer
-    types can be provided assuming they following the `ngen.config.path_path.protocol` `Reader` and
+    types can be provided assuming they following the `ngen.config.path_pair.protocol` `Reader` and
     `Writer` protocols (interfaces). This could, for example, enable reading and writing from the
     network.
 
     serializer's and deserializer's are type specific, and thus have no default. However,
-    `ngen.config.path_path.common` contains generic serializers and deserializer that may be of
+    `ngen.config.path_pair.common` contains generic serializers and deserializer that may be of
     interest (e.g. `pydantic_serializer` and `pydantic_deserializer`). Alternative serializer and
-    deserializer types can be provided assuming they follow the `ngen.config.path_path.protocol`
+    deserializer types can be provided assuming they follow the `ngen.config.path_pair.protocol`
     `Serializer` and `Deserializer` protocols (interfaces).
     """
 

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -52,7 +52,7 @@ class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
     @classmethod
     def with_object(
         cls,
-        o: T,
+        obj: T,
         *,
         path: StrPath = "",
         reader: Reader = path_reader,
@@ -62,7 +62,7 @@ class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
     ) -> Union["PosixPathPair[T]", "WindowsPathPair[T]"]:
         return cls(
             Path(path),
-            inner=o,
+            inner=obj,
             reader=reader,
             writer=writer,
             serializer=serializer,
@@ -176,7 +176,7 @@ class PathPairCollection(AbstractPathPairCollectionMixin[T], Path, Generic[T]):
     @classmethod
     def with_objects(
         cls,
-        o: List[T],
+        objs: List[T],
         *,
         path: Path,
         pattern: str,
@@ -186,12 +186,12 @@ class PathPairCollection(AbstractPathPairCollectionMixin[T], Path, Generic[T]):
         serializer: Optional[Serializer[T]] = None,
         deserializer: Optional[Deserializer[T]] = None,
     ) -> Union["PosixPathPairCollection[T]", "WindowsPathPairCollection[T]"]:
-        assert len(o) == len(ids)
+        assert len(objs) == len(ids)
         prefix, _, suffix = path.name.partition(pattern)
         assert prefix != "" and suffix != ""
 
         pairs = []
-        for idx, item in enumerate(o):
+        for idx, item in enumerate(objs):
             fp = path.parent / f"{prefix}{ids[idx]}{suffix}"
             pair = PathPair.with_object(
                 item,

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -60,8 +60,8 @@ class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
         o: T,
         *,
         path: StrPath = "",
-        reader: Optional[Reader] = path_reader,
-        writer: Optional[Writer] = path_writer,
+        reader: Reader = path_reader,
+        writer: Writer = path_writer,
         serializer: Optional[Serializer[T]] = None,
         deserializer: Optional[Deserializer[T]] = None,
     ) -> Union["PosixPathPair[T]", "WindowsPathPair[T]"]:

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -6,13 +6,8 @@ from .common import path_reader, path_writer
 from ._abc_mixins import AbstractPathPairMixin, AbstractPathPairCollectionMixin
 from ._mixins import PathPairMixin, PathPairCollectionMixin
 
-from typing import (
-    Any,
-    Generic,
-    Optional,
-    Union,
-    List,
-)
+from typing import Any, Dict, Generic, Optional, Union, List
+from typing_extensions import Self
 from .typing import StrPath, T
 
 
@@ -72,8 +67,22 @@ class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
             writer=writer,
             serializer=serializer,
             deserializer=deserializer,
-        )
+        )  # type: ignore
 
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: Dict[str, Any]):
+        field_schema.clear()
+        field_schema["format"] = "path"
+        field_schema["type"] = "string"
+
+    @classmethod
+    def validate(cls, value: Any) -> Self:
+        if isinstance(value, PathPair):
+            return value
 
         return PathPair(value)
 
@@ -203,6 +212,23 @@ class PathPairCollection(AbstractPathPairCollectionMixin[T], Path, Generic[T]):
             serializer=serializer,
             deserializer=deserializer,
         )
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: Dict[str, Any]):
+        field_schema.clear()
+        field_schema["format"] = "path"
+        field_schema["type"] = "string"
+
+    @classmethod
+    def validate(cls, value: Any) -> Self:
+        if isinstance(value, PathPairCollection):
+            return value
+
+        return PathPairCollection(value, pattern="")
 
 
 class PosixPathPair(PathPairMixin[T], PathPair[T], PosixPath):

--- a/python/ngen_conf/src/ngen/config/path_pair/protocol.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/protocol.py
@@ -11,20 +11,32 @@ from .typing import T, S
 
 
 class Writer(Protocol):
+    """
+    Function that writes data to a path or elsewhere (e.g. network).
+    """
     def __call__(self, p: Path, data: bytes) -> None:
         ...
 
 
 class Reader(Protocol):
+    """
+    Function that reads data from a file path or elsewhere (e.g. network).
+    """
     def __call__(self, p: Path) -> bytes:
         ...
 
 
 class Deserializer(Protocol[T]):
+    """
+    Function that given bytes returns a T.
+    """
     def __call__(self, data: bytes) -> T:
         ...
 
 
 class Serializer(Protocol[S]):
+    """
+    Function that given a T returns bytes.
+    """
     def __call__(self, o: S) -> bytes:
         ...

--- a/python/ngen_conf/src/ngen/config/path_pair/protocol.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/protocol.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from typing import Protocol
+from .typing import T, S
+
+
+class Writer(Protocol):
+    def __call__(self, p: Path, data: bytes) -> None:
+        ...
+
+
+class Reader(Protocol):
+    def __call__(self, p: Path) -> bytes:
+        ...
+
+
+class Deserializer(Protocol[T]):
+    def __call__(self, data: bytes) -> T:
+        ...
+
+
+class Serializer(Protocol[S]):
+    def __call__(self, o: S) -> bytes:
+        ...

--- a/python/ngen_conf/src/ngen/config/path_pair/protocol.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/protocol.py
@@ -1,6 +1,12 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
 from pathlib import Path
 
-from typing import Protocol
 from .typing import T, S
 
 

--- a/python/ngen_conf/src/ngen/config/path_pair/typing.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/typing.py
@@ -3,6 +3,8 @@ from typing import Union, TypeVar
 from typing_extensions import TypeAlias
 
 T = TypeVar("T", bound=object, covariant=True)
+"""Some type T or a subtype of T"""
 S = TypeVar("S", bound=object, contravariant=True)
+"""Some type S or a _supertype_ of S"""
 
 StrPath: TypeAlias = Union[Path, str]

--- a/python/ngen_conf/src/ngen/config/path_pair/typing.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/typing.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from typing import Union, TypeVar
+from typing_extensions import TypeAlias
+
+T = TypeVar("T", bound=object, covariant=True)
+S = TypeVar("S", bound=object, contravariant=True)
+
+StrPath: TypeAlias = Union[Path, str]

--- a/python/ngen_conf/tests/test_path_pair.py
+++ b/python/ngen_conf/tests/test_path_pair.py
@@ -1,4 +1,3 @@
-import inspect
 import pytest
 import tempfile
 from pydantic import BaseModel

--- a/python/ngen_conf/tests/test_path_pair.py
+++ b/python/ngen_conf/tests/test_path_pair.py
@@ -97,3 +97,103 @@ def test_path_read(path_pair: PosixPathPair[InnerModel]):
         assert p.exists()
         assert o2.read() == True
         assert o2.inner == o.inner == path_pair.inner
+
+
+@pytest.fixture
+def collection() -> PosixPathPairCollection[InnerModel]:
+    """Does not try to clean up and created assets."""
+    p = Path("id_{id}_data.txt")
+    pattern = "{id}"
+    models = [InnerModel(foo=i) for i in range(12)]
+    ids = list(map(lambda s: str(s), range(12)))
+
+    return PathPairCollection.from_objects(
+        models,
+        pattern=pattern,
+        path=p,
+        ids=ids,
+        serializer=pydantic_serializer,
+        deserializer=pydantic_deserializer(InnerModel),
+    )
+
+
+@pytest.fixture
+def temp_collection(
+    collection: PosixPathPairCollection[InnerModel],
+) -> PosixPathPairCollection[InnerModel]:
+    """
+    `PathPairCollection` backed by a temp directory. This guarantees that files / dirs created in the
+    temp dir will be cleaned up once the test using this fixture has run.
+
+    Only use this if you need to test writing / reading.
+    """
+    with tempfile.TemporaryDirectory() as dir:
+        o = Path(dir) / collection
+        yield o
+        o.unlink(missing_ok=True)
+
+
+def test_path_pair_collection_write(
+    temp_collection: PosixPathPairCollection[InnerModel],
+):
+    prefix, _, suffix = temp_collection.name.partition(temp_collection.pattern)
+    glob_term = f"{prefix}*{suffix}"
+
+    # assert no files have been written
+    assert len(list(temp_collection.parent.glob(glob_term))) == 0
+
+    temp_collection.write()
+
+    # assert all files have been written
+    assert len(list(temp_collection.parent.glob(glob_term))) == len(
+        list(temp_collection.inner)
+    )
+
+
+def test_path_pair_collection_read(
+    temp_collection: PosixPathPairCollection[InnerModel],
+):
+    prefix, _, suffix = temp_collection.name.partition(temp_collection.pattern)
+    glob_term = f"{prefix}*{suffix}"
+
+    assert len(list(temp_collection.parent.glob(glob_term))) == 0
+
+    temp_collection.write()
+
+    c2 = PathPairCollection(
+        temp_collection,
+        pattern=temp_collection.pattern,
+        deserializer=temp_collection._deserializer,
+    )
+
+    assert c2.read() == True
+
+    # sort inner list[ObjectPosixPathPair] b.c. _get_filenames uses `glob` which is not ordered
+    temp_collection._inner.sort()
+    c2._inner.sort()
+
+    # this compares Path values, not inner
+    assert temp_collection._inner == c2._inner
+
+    for col_item, c2_item in zip(temp_collection._inner, c2._inner):
+        assert col_item.inner == c2_item.inner
+
+
+def test_path_pair_collection_truediv_is_noop(
+    collection: PosixPathPairCollection[InnerModel],
+):
+    o = collection / "test"
+    assert o == collection
+
+
+def test_path_pair_collection_rtruediv(
+    collection: PosixPathPairCollection[InnerModel],
+):
+    new_root = Path("new/root")
+    o = new_root / collection
+
+    assert o == new_root / collection.name
+    assert type(o) == type(collection)
+    for prev_pair, new_pair in zip(collection.inner_pair, o.inner_pair):
+        assert prev_pair.name == new_pair.name
+        assert new_pair.parent == new_root

--- a/python/ngen_conf/tests/test_path_pair.py
+++ b/python/ngen_conf/tests/test_path_pair.py
@@ -186,14 +186,6 @@ def test_path_pair_collection_truediv_is_noop(
     assert type(o) == type(collection)
 
 
-def test_path_pair_collection_with_path_is_noop(
-    collection: PosixPathPairCollection[InnerModel],
-):
-    o = collection.with_path("test")
-    assert o == collection
-    assert type(o) == type(collection)
-
-
 def test_path_pair_collection_rtruediv(
     collection: PosixPathPairCollection[InnerModel],
 ):

--- a/python/ngen_conf/tests/test_path_pair.py
+++ b/python/ngen_conf/tests/test_path_pair.py
@@ -1,0 +1,99 @@
+import inspect
+import pytest
+import tempfile
+from pydantic import BaseModel
+from pathlib import Path
+
+from ngen.config.path_pair import (
+    PathPair,
+    PosixPathPair,
+    PathPairCollection,
+    PosixPathPairCollection,
+)
+from ngen.config.path_pair.common import pydantic_deserializer, pydantic_serializer
+
+
+class InnerModel(BaseModel):
+    foo: int
+
+
+class Model(BaseModel):
+    p: Path
+
+
+@pytest.fixture
+def path_pair() -> PosixPathPair[InnerModel]:
+    m = InnerModel(foo=12)
+    return PathPair(
+        "",
+        inner=m,
+        serializer=pydantic_serializer,
+        deserializer=pydantic_deserializer(InnerModel),
+    )
+
+
+def test_path_pair_from_object():
+    m = InnerModel(foo=12)
+    o = PathPair.from_object(m, serializer=pydantic_serializer)
+    assert o == Path("")
+    assert o.inner == m
+
+
+def test_path_pair_with_path(path_pair: PosixPathPair[InnerModel]):
+    assert path_pair != Path("/")
+
+    o2 = path_pair.with_path("/")
+    assert o2 == Path("/")
+    assert o2.inner == path_pair.inner
+
+
+def test_path_truediv(path_pair: PosixPathPair[InnerModel]):
+    assert path_pair != Path("test")
+
+    o = path_pair / "test"
+
+    assert o == Path("test")
+    assert o.inner == path_pair.inner
+
+    o /= "test"
+    assert o == Path("test/test")
+    assert o.inner == path_pair.inner
+
+
+def test_path_rtruediv(path_pair: PosixPathPair[InnerModel]):
+    o = "test/test" / path_pair
+    assert o == Path("test/test")
+    assert o.inner == path_pair.inner
+
+
+def test_path_serialize(path_pair: PosixPathPair[InnerModel]):
+    assert path_pair.serialize() == path_pair.inner.json().encode()
+
+
+def test_path_deserialize(path_pair: PosixPathPair[InnerModel]):
+    data = path_pair.serialize()
+    o = PosixPathPair(path_pair, deserializer=path_pair._deserializer)
+    assert o.deserialize(data) == True
+    assert o.inner == path_pair.inner
+
+
+def test_path_write(path_pair: PosixPathPair[InnerModel]):
+    with tempfile.NamedTemporaryFile() as f:
+        p = Path(f.name)
+        o = path_pair.with_path(p)
+        o.write()
+        assert p.read_bytes() == o.serialize()
+        assert p.is_file()
+        assert p.exists()
+
+
+def test_path_read(path_pair: PosixPathPair[InnerModel]):
+    with tempfile.NamedTemporaryFile() as f:
+        p = Path(f.name)
+        o = path_pair.with_path(p)
+        o.write()
+        o2 = PathPair(o, deserializer=path_pair._deserializer)
+        assert p.is_file()
+        assert p.exists()
+        assert o2.read() == True
+        assert o2.inner == o.inner == path_pair.inner

--- a/python/ngen_conf/tests/test_path_pair.py
+++ b/python/ngen_conf/tests/test_path_pair.py
@@ -81,7 +81,7 @@ def test_path_write(path_pair: PosixPathPair[InnerModel]):
     with tempfile.NamedTemporaryFile() as f:
         p = Path(f.name)
         o = path_pair.with_path(p)
-        o.write()
+        assert o.write() == True
         assert p.read_bytes() == o.serialize()
         assert p.is_file()
         assert p.exists()
@@ -91,7 +91,7 @@ def test_path_read(path_pair: PosixPathPair[InnerModel]):
     with tempfile.NamedTemporaryFile() as f:
         p = Path(f.name)
         o = path_pair.with_path(p)
-        o.write()
+        assert o.write() == True
         o2 = PathPair(o, deserializer=path_pair._deserializer)
         assert p.is_file()
         assert p.exists()
@@ -142,7 +142,7 @@ def test_path_pair_collection_write(
     # assert no files have been written
     assert len(list(temp_collection.parent.glob(glob_term))) == 0
 
-    temp_collection.write()
+    assert temp_collection.write() == True
 
     # assert all files have been written
     assert len(list(temp_collection.parent.glob(glob_term))) == len(
@@ -158,7 +158,7 @@ def test_path_pair_collection_read(
 
     assert len(list(temp_collection.parent.glob(glob_term))) == 0
 
-    temp_collection.write()
+    assert temp_collection.write() == True
 
     c2 = PathPairCollection(
         temp_collection,

--- a/python/ngen_conf/tests/test_path_pair.py
+++ b/python/ngen_conf/tests/test_path_pair.py
@@ -33,7 +33,7 @@ def path_pair() -> PosixPathPair[InnerModel]:
 
 def test_path_pair_from_object():
     m = InnerModel(foo=12)
-    o = PathPair.from_object(m, serializer=pydantic_serializer)
+    o = PathPair.with_object(m, serializer=pydantic_serializer)
     assert o == Path("")
     assert o.inner == m
 
@@ -106,7 +106,7 @@ def collection() -> PosixPathPairCollection[InnerModel]:
     models = [InnerModel(foo=i) for i in range(12)]
     ids = list(map(lambda s: str(s), range(12)))
 
-    return PathPairCollection.from_objects(
+    return PathPairCollection.with_objects(
         models,
         pattern=pattern,
         path=p,


### PR DESCRIPTION
Add new `PathPair` and `PathPairCollection` types that encapsulate a `pathlib.Path` and some inner `T` or collection of `T`'s. Beyond encapsulation, these types also provide APIs for flexibly writing, reading, serializing, deserializing to and from the inner `T` / `T`'s.

This functionality is desirable, among other use cases, when using `pydantic` and want to represent a field that de/serializes as a `pathlib.Path` but holds onto an inner deserialized `T` (this could be another pydantic model for example).

```python
from pydantic import BaseModel, validator
from ngen.config.path_pair import PathPair
from ngen.config.path_pair.common import pydantic_serializer, pydantic_deserializer
import tempfile
from typing import Union

class Inner(BaseModel):
    foo: int

class Outer(BaseModel):
    path: PathPair[Inner]

    @validator("path", pre=True)
    def _coerce_path(cls, value: Union[PathPair[Inner], str]) -> PathPair[Inner]:
        if isinstance(value, PathPair):
            return value
        value = PathPair(
            value,
            serializer=pydantic_serializer,
            deserializer=pydantic_deserializer(Inner),
        )
        try:
            # read and deserialize from path into Inner
            value.read()
        except:
            ...
        return value

def test_outer():
    with tempfile.NamedTemporaryFile() as file:
        path_to_file = Path(file.name)

        inner = Inner(foo=12)
        inner_path_pair = PathPair.with_object(
            inner,
            path=path_to_file,
            serializer=pydantic_serializer,
            deserializer=pydantic_deserializer(Inner),
        )
        # serialize inner T, Inner and **write to disc**
        assert inner_path_pair.write() == True

        # when pydanatic validates this, we will **read in and deserialize**
        # into the Inner type
        outer = Outer(path=path_to_file)
        assert outer.path == path_to_file
        assert outer.path.inner == inner
```

<details>
<summary><code>PathPairCollection</code> example</summary>

```python
class OuterWithPathPairCollection(BaseModel):
    path: PathPairCollection[Inner]

    _path_pattern: ClassVar[str] = "{id}"

    @validator("path", pre=True)
    def _coerce_path(
        cls, value: Union[PathPairCollection[Inner], str]
    ) -> PathPairCollection[Inner]:
        if isinstance(value, PathPairCollection):
            return value

        value = PathPairCollection(
            value,
            pattern=cls._path_pattern,
            serializer=pydantic_serializer,
            deserializer=pydantic_deserializer(Inner),
        )
        try:
            # read and deserialize all files that match the pattern into Inner
            value.read()
        except:
            ...
        return value


def test_path_pair_collection_integration_with_pydantic_model():
    with tempfile.TemporaryDirectory() as dir:
        path_dir = Path(dir)

        path = path_dir / "cool_file_number_{id}.json"

        inner_models = [Inner(foo=i) for i in range(2)]

        inner_path_pair_collection = PathPairCollection.with_objects(
            inner_models,
            pattern="{id}",
            ids=[str(i) for i in range(2)],
            path=path,
            serializer=pydantic_serializer,
            deserializer=pydantic_deserializer(Inner),
        )

        # serialize inner Ts, Inner, and write them to disc
        assert inner_path_pair_collection.write() == True

        for path_pair in inner_path_pair_collection.inner_pair:
            print(path_pair)
        # >>> /.../cool_file_number_0.json
        # >>> /.../cool_file_number_1.json

        # when pydanatic validates this, we will read all matching paths and
        # deserialize into the Inner type
        outer = OuterWithPathPairCollection(path=path)
        assert outer.path == path

        for deserialized_inner in outer.path.inner:
            # read ordering is not guaranteed, so we will just do a contains check.
            # we could have sorted instead though.
            assert deserialized_inner in inner_models

```

</details>

You could also imagine writing a function that iterates over all fields in a pydantic model and if the field is a `PathPair` or `PathPairCollection` calling that field's `write()` method. That might look something like:

```python
from pydantic import BaseModel
from ngen.config.path_pair import PathPair, PathPairCollection


def write_path_pairs(m: BaseModel):
    for field_name in m.__fields_set__:
        field = getattr(m, field_name)
        if isinstance(field, (PathPair, PathPairCollection)):
            field.write()
        elif isinstance(field, BaseModel):
            write_path_pairs(field)
```


## Additions

- New `PathPair` and `PathPairCollection` types that encapsulate a `pathlib.Path` and some inner `T` or collection of `T`'s.

## Testing

1. Unit tests are included for both `PathPair` and `PathPairCollection`

## TODO:

- [ ] Bump `ngen.config` version prior to merge
- [ ] Update changelog ""


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
