### PR TITLE
List dependency versions in gh actions

### DIFF
--- a/.github/workflows/ngen-cal.yaml
+++ b/.github/workflows/ngen-cal.yaml
@@ -54,6 +54,11 @@ jobs:
       #for now, just turning off 3.11 for this test...
       #continue-on-error: ${{matrix.python-version == 3.11 }}
 
+    - name: List dependency versions
+      run: |
+        source ./venv/bin/activate
+        pip freeze
+
     - name: Testing ngen_cal with pytest
       run: |
         source ./venv/bin/activate

--- a/.github/workflows/ngen-conf.yml
+++ b/.github/workflows/ngen-conf.yml
@@ -42,6 +42,11 @@ jobs:
         pip install -U pip
         pip install "python/ngen_conf[develop]"
 
+    - name: List dependency versions
+      run: |
+        source ./venv/bin/activate
+        pip freeze
+
     - name: Testing ngen_conf with pytest
       run: |
         source ./venv/bin/activate

--- a/.github/workflows/ngen-init-config.yml
+++ b/.github/workflows/ngen-init-config.yml
@@ -42,7 +42,12 @@ jobs:
         pip install -U pip
         pip install "python/ngen_init_config[develop]"
 
-    - name: Testing ngen_init_config with pytest
+    - name: List dependency versions
+      run: |
+        source ./venv/bin/activate
+        pip freeze
+
+    - name: Testing ngen.init_config with pytest
       run: |
         source ./venv/bin/activate
         pytest python/ngen_init_config


### PR DESCRIPTION
`pip freeze` dependency versions in gh actions. This is mainly for debugging purposes in the case that test runners start failing.