### PR TITLE
Bump ngen.cal pandas dependency to pandas >=1.1.2

### DIFF
--- a/python/ngen_cal/setup.cfg
+++ b/python/ngen_cal/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
     =src
 install_requires =
     pydantic<2
-    pandas~=1.1.2
+    pandas>=1.1.2
     geopandas
     matplotlib
     hydrotools.metrics


### PR DESCRIPTION
In reading through [`pandas` 2.0 change log](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.0.0.html#backwards-incompatible-api-changes) and reviewing the existing code, we don't appear to use any features that were broken in 2.0. @hellkite500, can you have another look to audit that codebase and double check me? Luckily, there arent too many places where pandas is being used. 

## Changes

- Bump ngen.cal pandas dependency to pandas >=1.1.2

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
