### PR TITLE
Dev branch - addressing issue #69 workdir used incorrectly in agent construction

### DIFF
--- a/python/ngen_cal/src/ngen/cal/agent.py
+++ b/python/ngen_cal/src/ngen/cal/agent.py
@@ -79,12 +79,10 @@ class Agent(BaseAgent):
         if self._job is None:
             self._job = JobMeta(model_conf['type'], workdir, log=log)
         resolved_binary = Path(model_conf['binary']).resolve()
-        # relative_to = model_conf['workdir'] BChoat - delete after testing
         model_conf['workdir'] = self.job.workdir
         self._model = Model(model=model_conf, binary=resolved_binary)
         self._model.model.resolve_paths(self.job.workdir)
 
-        # self._model.model.resolve_paths(relative_to)
         self._params = parameters
     
     @property

--- a/python/ngen_cal/src/ngen/cal/agent.py
+++ b/python/ngen_cal/src/ngen/cal/agent.py
@@ -79,10 +79,12 @@ class Agent(BaseAgent):
         if self._job is None:
             self._job = JobMeta(model_conf['type'], workdir, log=log)
         resolved_binary = Path(model_conf['binary']).resolve()
-        relative_to = model_conf['workdir']
+        # relative_to = model_conf['workdir'] BChoat - delete after testing
         model_conf['workdir'] = self.job.workdir
         self._model = Model(model=model_conf, binary=resolved_binary)
-        self._model.model.resolve_paths(relative_to)
+        self._model.model.resolve_paths(self.job.workdir)
+
+        # self._model.model.resolve_paths(relative_to)
         self._params = parameters
     
     @property


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- 

## Removals

-  Removed line 82: relative_to = model_conf['workdir']

## Changes

- Edited line 85 from, `self._model.model.resolve_paths(relative_to)` to `self._model.model.resolve_paths(self.job.workdir)`

## Testing

1. After receiving errors about 'workdir' not being in model_conf, edits above were made. To test, reran calibration scripts, and error no longer appeared.

## Screenshots


## Notes

- Running on Ubuntu 22.04

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [ x] Changes are limited to a single goal (no scope creep)
- [ x] Code can be automatically merged (no conflicts)
- [ x] Code follows project standards (link if applicable)
- [ x] Passes all existing automated tests
- [ x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x ] Linux
- [ ] MacOS
