### PR TITLE
Update objectives.py so uses kge instead of 1-kge

### DIFF
--- a/python/ngen_cal/src/ngen/cal/objectives.py
+++ b/python/ngen_cal/src/ngen/cal/objectives.py
@@ -24,7 +24,7 @@ def inverted_nnse(observed, simulated):
     return 1 - nnse
 
 def kge(observed, simulated):
-    return 1 - kling_gupta_efficiency(observed, simulated)
+    return kling_gupta_efficiency(observed, simulated)
 
 def peak_error_single(observed, simulated):
     max_sim = simulated.max()


### PR DESCRIPTION
I think as an artifact of previous times when all optimization was done via minimization, if a user wanted to optimize using 'kling_gupta', they would have to specify 'min' as target. This is completely counterintuitive since kge should be maxmized (-inf<kge<=1 and kge=1 is best possible score). By using kge direclty, the user can intuitively set the target as 'max'.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux
- [ ] MacOS
