### PR TITLE
Update cfe.py - remove QINSUR as default variable name mapping

### DIFF
--- a/python/ngen_conf/src/ngen/config/cfe.py
+++ b/python/ngen_conf/src/ngen/config/cfe.py
@@ -27,5 +27,5 @@ class CFE(BMIC):
     #will also include these mappings
     _variable_names_map =  {
         #"water_potential_evaporation_flux": "EVAPOTRANS",
-        "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR"
+        #"atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR"
         }


### PR DESCRIPTION
When cfe is ran with PET (PET->CFE) QINSUR  is not an output file of PET and including this as a default mapping breaks the calibration either immediately or after the first iteration when the ngen configuration file (e.g., Realization_pet_cfe_calibNC.json) is updated.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux
- [ ] MacOS
