### PR TITLE
Represent and resolve NextGen BMI module input and output variables

### DIFF
--- a/python/ngen_conf/src/ngen/config/model_vars.py
+++ b/python/ngen_conf/src/ngen/config/model_vars.py
@@ -1,0 +1,578 @@
+"""
+This module contains functions and abstractions for representing and resolving NextGen BMI module
+input and output variables.
+
+Functions of note:
+- `resolve_model_inputs`: Returns the input mappings and missing inputs for a single model.
+- `resolve_inputs_mapping`: Returns the input mappings and missing inputs for a list of models (often, multi-bmi).
+- `resolve_outputs_mapping`: Returns the set of invalid output names / aliases for a list of models.
+
+Classes of note:
+- `Var`: Represents the concept of a NextGen BMI variable.
+- `Inputs`: Represents the input variables and alias re-mappings of a NextGen BMI module.
+- `Outputs`: Represents the output variables and alias mappings of a NextGen BMI module.
+- `InputsBuilder`: Builder object for creating new `Inputs` instances.
+- `OutputsBuilder`: Builder object for creating new `Outputs` instances.
+"""
+from __future__ import annotations
+
+import collections
+import copy
+import dataclasses
+import typing
+
+import typing_extensions
+from typing_extensions import Self
+
+
+class ModelInputMeta(typing_extensions.Protocol):
+    """
+    The name of a BMI module and it's inputs
+    """
+
+    def name(self) -> str:
+        ...
+
+    def inputs(self) -> Inputs:
+        ...
+
+
+class ModelOutputMeta(typing_extensions.Protocol):
+    """
+    The name of a BMI module and it's outputs
+    """
+
+    def name(self) -> str:
+        ...
+
+    def outputs(self) -> Outputs:
+        ...
+
+
+class ModelMeta(typing_extensions.Protocol):
+    """
+    The name of a BMI module and it's inputs and outputs
+    """
+
+    def name(self) -> str:
+        ...
+
+    def inputs(self) -> Inputs:
+        ...
+
+    def outputs(self) -> Outputs:
+        ...
+
+
+@dataclasses.dataclass
+class Var:
+    """
+    Structure that captures the concept of a NextGen BMI variable.
+    """
+
+    name: str
+
+
+class Inputs:
+    """
+    Representation of a NextGen BMI module's input variables and alias re-mappings.
+
+    The general rules NextGen enforces for input variables are:
+    - all inputs must receive data from some provider (e.g. forcing, a previous module)
+    - an alias to an input name will always be used. only alias will be used to locate data provider
+    - inputs can have the same alias name (i.e. 2 inputs receive data from same provider)
+    - alias to an input name that does not exist is a no-op (alias is ignored)
+    - only the first provided alias to an input name is used
+
+    The general rules NextGen enforces for input variables in a Multi-BMI formulation are:
+    - input names and aliases are module scoped (i.e. ok to have 2 modules with same input name)
+
+    Example:
+        inputs = InputsBuilder().add_input(
+            Var(name="APCP_surface"), "atmosphere_water__rainfall_volume_flux"
+        ).build()
+
+        assert inputs.resolve_name("APCP_surface") == "atmosphere_water__rainfall_volume_flux"
+
+        assert inputs.var("APCP_surface") == Var(name="APCP_surface")
+
+        assert inputs.mapping() == {"APCP_surface": "atmosphere_water__rainfall_volume_flux"}
+
+        assert list(inputs.inputs()) == [Var(name="APCP_surface")]
+    """
+
+    def __init__(self):
+        # mapping of var name to _VarAliasPair
+        self._inputs: dict[str, _VarAliasPair] = dict()
+        self._mapping: dict[str, str] | None = None
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(inputs={self._inputs})"
+
+    def resolve_name(self, name: str) -> str:
+        """
+        Return alias if it exists or the input's name
+        `KeyError` if the name is not mapped.
+        """
+        var = self._get_input(name)
+        if var is None:
+            # probably should just warn here and return name
+            raise KeyError(f"var {name!r} does not exist")
+        return var.resolve_name()
+
+    def var(self, name: str) -> Var:
+        """
+        Get the Var instance mapped to a given input name.
+
+        `KeyError` if the name is not mapped.
+        """
+        var = self._get_input(name)
+        if var is None:
+            # probably should just warn here and return name
+            raise KeyError(f"var {name!r} does not exist")
+        return var.var
+
+    def mapping(self) -> dict[str, str]:
+        """
+        Return mapping of var name to alias name.
+        If an alias does not exist, mapping is from var name to var name.
+        """
+        if self._mapping is None:
+            self._mapping = {
+                name: var.resolve_name() for name, var in self._inputs.items()
+            }
+        return self._mapping
+
+    def inputs(self) -> typing.Iterator[Var]:
+        """
+        Iterator of Var's in Input instance
+        """
+        return (var.var for var in self._inputs.values())
+
+    def _add_input(self, *, input: Var, alias: str | None = None):
+        """
+        Add input and potentially an alias.
+        Overwrites an existing input with the same name.
+
+        Note: this is private to explicitly separate creation from usage.
+        """
+        self._inputs[input.name] = _VarAliasPair(var=input, alias=alias)
+
+    def _add_alias(self, *, name: str, alias: str):
+        """
+        Add an alias to an existing input.
+
+        Overwrites an existing alias if it exists. For example, if input with
+        name `Q` has existing alias `q` and `_add_alias("Q", "discharge")` is
+        called, `Q`'s alias will be changed.
+
+        `KeyError` if input does not exist.
+
+        Note: this is private to explicitly separate creation from usage.
+        """
+        input = self._get_input(name)
+        if input is None:
+            # probably should just warn here that it is a no-op
+            raise KeyError(f"input: {name!r} does not exist")
+        input.alias = alias
+
+    def __iter__(self) -> typing.Iterator[Var]:
+        return self.inputs()
+
+    def _get_input(self, name: str) -> _VarAliasPair | None:
+        """
+        Get _VarAliasPair given a name.
+        """
+        return self._inputs.get(name)
+
+
+class Outputs:
+    """
+    Representation of a NextGen BMI module's output variables and alias mappings.
+
+    The general rules NextGen enforces for output variables are:
+    - output names and aliases must be unique
+    - an output name can have multiple aliases
+
+    The general rules NextGen enforces for output variables in a Multi-BMI formulation are:
+    - module's requiring data as input can refer to other module's output by name _or_ aliases.
+    - edge cases: if 2+ modules have the same output name:
+        - if all modules alias the output name and another module requires input data by output
+        _name_, the first module in the modules list with the output name will provide data.
+        - if all _but one_ module aliases the output name and another module requires input data
+        by output _name_, the module that _does not_ define an alias will provide data.
+
+    For other information see
+    [NextGen Docs](https://github.com/NOAA-OWP/ngen/blob/master/doc/BMI_MODELS.md#optional-parameters).
+
+    Example:
+        outputs = OutputsBuilder().add_output(
+            Var(name="ETRAN"), "land_vegetation_canopy_water__transpiration_volume_flux"
+        ).build()
+
+        assert outputs.resolve_var("ETRAN") == Var(name="ETRAN")
+        assert outputs.resolve_var(
+            "land_vegetation_canopy_water__transpiration_volume_flux"
+        ) == Var(name="ETRAN")
+
+        assert outputs.mapping() == {"ETRAN": {"ETRAN", "land_vegetation_canopy_water__transpiration_volume_flux"}}
+
+        assert list(outputs.outputs()) == [Var(name="ETRAN")]
+
+        assert list(outputs.names()) == ["ETRAN", "land_vegetation_canopy_water__transpiration_volume_flux"]
+
+        assert outputs.alias("ETRAN") == Var(name="ETRAN")
+
+        assert outputs.var("ETRAN") == Var(name="ETRAN")
+    """
+
+    def __init__(self):
+        # mapping of name or alias to Var instance
+        self._outputs: dict[str, Var] = dict()
+        self._mapping: dict[str, set[str]] | None = None
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(outputs={self._outputs})"
+
+    def resolve_var(self, name_or_alias: str) -> Var | None:
+        """
+        Given a name _or_ alias, return the associated output var if it exists.
+        """
+        return self._get_output(name_or_alias)
+
+    def mapping(self) -> dict[str, set[str]]:
+        """
+        Return mapping of output var name to it's aliases and itself.
+        """
+        if self._mapping is None:
+            mapping: dict[str, set[str]] = collections.defaultdict(set)
+            for name_or_alias, var in self._outputs.items():
+                mapping[var.name].add(name_or_alias)
+            self._mapping = mapping
+        return dict(self._mapping)
+
+    def outputs(self) -> typing.Iterator[Var]:
+        """
+        Iterator of output Vars. Does not include aliases.
+        """
+        return (var for name, var in self._outputs.items() if name == var.name)
+
+    def names(self) -> typing.Iterator[str]:
+        """
+        Iterator of all output Var and alias names.
+        """
+        return (name for name in self._outputs.keys())
+
+    def _add_output(self, *, output: Var, alias: str | None = None):
+        """
+        Add output and potentially an alias.
+        `KeyError` if `output` var _or_ `alias` mapping already exists.
+
+        Note: this is private to explicitly separate creation from usage.
+        """
+        if output.name in self._outputs:
+            raise KeyError(f"output: {output.name!r} already exists")
+        if alias in self._outputs:
+            raise KeyError(f"alias: {alias!r} already exists")
+        if alias is not None:
+            self._outputs[alias] = output
+        self._outputs[output.name] = output
+
+    def _add_alias(self, *, name: str, alias: str):
+        """
+        Add an alias to an existing output.
+
+        `KeyError` if `output` mapping _does not_ exist.
+        `KeyError` if `alias` mapping already exists.
+
+        Note: this is private to explicitly separate creation from usage.
+        """
+        if alias in self._outputs:
+            raise KeyError(f"alias: {alias!r} already exists")
+
+        output = self._get_output(name)
+        if output is None:
+            raise KeyError(f"output: {name!r} does not exist")
+
+        self._outputs[alias] = output
+
+    def _get_output(self, name: str) -> Var | None:
+        """
+        Get Var given a name.
+        """
+        return self._outputs.get(name)
+
+    def _is_mapped(self, name_or_alias: str) -> bool:
+        """
+        Test if a name / alias is mapped.
+        """
+        return name_or_alias in self._outputs
+
+
+class InputsBuilder:
+    """
+    Builder object for creating new `Inputs` instances.
+
+    Example:
+        InputsBuilder().add_input(Var(name="APCP_surface")).build()
+
+        # alias `APCP_surface` as `atmosphere_water__rainfall_volume_flux`.
+        inputs = (
+            InputsBuilder()
+            .add_input(Var(name="APCP_surface"))
+            .add_alias("APCP_surface", "atmosphere_water__rainfall_volume_flux")
+            .build()
+        )
+        # or like this
+        inputs = InputsBuilder().add_input(
+            Var(name="APCP_surface"), "atmosphere_water__rainfall_volume_flux"
+        ).build()
+    """
+
+    def __init__(self):
+        self._inputs = Inputs()
+
+    @classmethod
+    def from_inputs(cls, inputs: Inputs) -> Self:
+        """
+        Create a new `InputBuilder` from an existing `Inputs`.
+
+        Safety: `inputs` is deep copied, so it is safe to use and mutate
+                after calling this.
+        """
+        inst = cls()
+        inst._inputs = copy.deepcopy(inputs)
+        return inst
+
+    def add_input(self, input: Var, alias: str | None = None) -> Self:
+        """
+        Add input and potentially an alias.
+        Overwrites an existing input with the same name.
+        """
+        self._inputs._add_input(input=input, alias=alias)
+        return self
+
+    def add_alias(self, name: str, alias: str) -> Self:
+        """
+        Add an alias to an existing input.
+
+        Overwrites an existing alias if it exists. For example, if input with
+        name `Q` has existing alias `q` and `add_alias("Q", "discharge")` is
+        called, `Q`'s alias will be changed.
+
+        `KeyError` if `name` does not exist.
+        """
+        self._inputs._add_alias(name=name, alias=alias)
+        return self
+
+    def build(self) -> Inputs:
+        """
+        Returns a new `Inputs` instance.
+
+        Safety: successive calls return new objects. So, it is safe to add
+                inputs, build, then add more inputs.
+        """
+        return copy.deepcopy(self._inputs)
+
+
+class OutputsBuilder:
+    def __init__(self):
+        self._outputs = Outputs()
+
+    @classmethod
+    def from_outputs(cls, outputs: Outputs) -> Self:
+        """
+        Create a new `OutputsBuilder` from an existing `Outputs`.
+
+        Safety: `outputs` is deep copied, so it is safe to use and mutate after
+                calling this.
+        """
+        inst = cls()
+        inst._outputs = copy.deepcopy(outputs)
+        return inst
+
+    def add_output(self, output: Var, *aliases: str) -> Self:
+        """
+        Add output and potentially aliases.
+        Overwrites an existing input with the same name.
+
+        `KeyError` if `output` var _or_ any `alias` mapping already exists.
+        """
+        self._outputs._add_output(output=output)
+        self.add_alias(output.name, *aliases)
+        return self
+
+    def add_alias(self, name: str, *aliases: str) -> Self:
+        """
+        Add aliases to a given output.
+
+        `KeyError` if any alias mapping already exists. No aliases will be
+         created if any alias already exists.
+        `KeyError` if `name` mapping _does not_ exist.
+        """
+        for alias in aliases:
+            if self._outputs._is_mapped(alias):
+                raise KeyError(f"alias: {alias!r} already exists")
+
+        for alias in aliases:
+            self._outputs._add_alias(name=name, alias=alias)
+        return self
+
+    def build(self) -> Outputs:
+        """
+        Returns a new `Outputs` instance.
+
+        Safety: successive calls return new objects. So, it is safe to add
+                outputs, build, then add more outputs.
+        """
+        return copy.deepcopy(self._outputs)
+
+
+class _VarAliasPair:
+    def __init__(self, var: Var, alias: str | None = None):
+        self.var: Var = var
+        # alias never has value var.name
+        self._alias: str | None = None if alias == var.name else alias
+
+    def resolve_name(self) -> str:
+        """Return alias is it exists or the input's name"""
+        if self.alias is not None:
+            return self.alias
+        return self.var.name
+
+    @property
+    def alias(self) -> str | None:
+        """
+        Invariant: alias does not equal `var.name`
+        """
+        return self._alias
+
+    @alias.setter
+    def alias(self, value: str | None) -> None:
+        if value == self.var.name:
+            value = None
+        self._alias = value
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(var={self.var!r}, alias={self.alias!r})"
+
+
+@dataclasses.dataclass
+class ModelVarMapping:
+    """
+    The name of a model and one of it's Var's.
+    """
+
+    model: str
+    var: Var
+
+
+@dataclasses.dataclass
+class VarMapping:
+    """
+    Structure that captures the concept of a source variable on some model, a destination variable
+    on some model, and a binding variable, `via`. Call `str()` on an instance for a visual
+    representation.
+
+    Graphically:
+        src(model::var) -> via -> dest(model::var)
+    """
+
+    src: ModelVarMapping
+    dest: ModelVarMapping
+    via: str
+
+    def is_src_alias(self) -> bool:
+        return self.src.var.name != self.via
+
+    def is_dest_alias(self) -> bool:
+        return self.dest.var.name != self.via
+
+    @typing_extensions.override
+    def __str__(self) -> str:
+        input_alias = f" as {self.via}" if self.is_src_alias() else ""
+        dest_alias = f" as {self.via}" if self.is_dest_alias() else ""
+        return f"{self.src.model}::{self.src.var.name}{input_alias} -> {self.dest.model}::{self.dest.var.name}{dest_alias}"
+
+
+def resolve_model_inputs(
+    model: ModelInputMeta, data_providers: typing.Iterable[ModelOutputMeta]
+) -> tuple[list[VarMapping], list[Var]]:
+    """
+    Return a tuple of valid input variable mappings and missing input variables mappings.
+    Aliases are accounted for.
+    """
+    # input var name -> src dest mapping
+    mapping: dict[str, VarMapping] = dict()
+    # input var name -> Var
+    maybe_missing: dict[str, Var] = dict()
+    for dest_name, dest_name_or_alias in model.inputs().mapping().items():
+        dest = ModelVarMapping(model=model.name(), var=model.inputs().var(dest_name))
+        for source in data_providers:
+            if dest_name in mapping:
+                assert dest_name not in maybe_missing
+                m = mapping[dest_name]
+                # only pick up new mappings if:
+                # - src provides data and has no aliases. follows that prev has an alias
+                src_aliases = source.outputs().mapping().get(m.src.var.name)
+                if src_aliases is not None and len(src_aliases) > 1:
+                    continue
+
+            var = source.outputs().resolve_var(dest_name_or_alias)
+            if var is not None:
+                src = ModelVarMapping(model=source.name(), var=var)
+                mapping[dest_name] = VarMapping(
+                    via=dest_name_or_alias, src=src, dest=dest
+                )
+
+            if dest_name not in mapping:
+                maybe_missing[dest_name] = dest.var
+            else:
+                maybe_missing.pop(dest_name, None)
+
+    return list(mapping.values()), list(maybe_missing.values())
+
+
+def resolve_inputs_mapping(
+    *models: ModelMeta,
+) -> tuple[dict[str, list[VarMapping]], dict[str, list[Var]]]:
+    """
+    Return a tuple of model name to valid input variable mappings and model name to missing input
+    variable mappings. Aliases are accounted for.
+    """
+    model_mapping: dict[str, list[VarMapping]] = collections.defaultdict(list)
+    missing: dict[str, list[Var]] = collections.defaultdict(list)
+    i = 1
+    for model in models[1:]:
+        mapped, unmapped = resolve_model_inputs(model, models[:i])
+        if mapped:
+            model_mapping[model.name()] = mapped
+        if unmapped:
+            missing[model.name()] = unmapped
+        i += 1
+    return dict(model_mapping), dict(missing)
+
+
+def resolve_outputs_mapping(models: typing.Iterable[ModelOutputMeta]) -> set[str]:
+    """
+    Validate a list of models follow NextGen's output variable invariants.
+    Returns the set of invalid output names / aliases.
+    """
+    duplicated: set[str] = set()
+    total: set[str] = set()
+
+    for model in models:
+        for name, aliases in model.outputs().mapping().items():
+            for alias in aliases:
+                if len(aliases) == 1:
+                    assert name == alias
+                # mapping contains mappings to alias _and_ name itself
+                # if mappings contains alias(es) don't account for self reference
+                if alias == name and len(aliases) > 1:
+                    continue
+                if alias in total:
+                    duplicated.add(alias)
+                else:
+                    total.add(alias)
+
+    return duplicated

--- a/python/ngen_conf/tests/test_model_vars.py
+++ b/python/ngen_conf/tests/test_model_vars.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import pytest
+
+from ngen.config.model_vars import (
+    Inputs,
+    InputsBuilder,
+    ModelMeta,
+    Outputs,
+    OutputsBuilder,
+    Var,
+    VarMapping,
+    resolve_inputs_mapping,
+    resolve_outputs_mapping,
+)
+
+
+class Model(ModelMeta):
+    def __init__(self, name: str, inputs: Inputs, outputs: Outputs):
+        self._name: str = name
+        self._inputs: Inputs = inputs
+        self._outputs: Outputs = outputs
+
+    def name(self) -> str:
+        return self._name
+
+    def inputs(self) -> Inputs:
+        return self._inputs
+
+    def outputs(self) -> Outputs:
+        return self._outputs
+
+    def __repr__(self) -> str:
+        return f"Model(name={self._name}, inputs={str(self._inputs)}, outputs={str(self._outputs)})"
+
+
+VALIDATE_OUTPUT_MAPPING_CASES = [
+    (
+        # model 1 Outputs
+        OutputsBuilder().build(),
+        # model 2 Outputs
+        OutputsBuilder().build(),
+        # expected
+        set(),
+    ),
+    (
+        OutputsBuilder().build(),
+        OutputsBuilder().add_output(Var(name="a")).build(),
+        set(),
+    ),
+    (
+        OutputsBuilder().add_output(Var(name="a")).build(),
+        OutputsBuilder().add_output(Var(name="b")).build(),
+        set(),
+    ),
+    (
+        OutputsBuilder().add_output(Var(name="a"), "b").build(),
+        OutputsBuilder().add_output(Var(name="b"), "a").build(),
+        set(),
+    ),
+    (
+        OutputsBuilder().add_output(Var(name="b")).build(),
+        OutputsBuilder().add_output(Var(name="b"), "a").build(),
+        set(),
+    ),
+    (
+        OutputsBuilder().add_output(Var(name="b"), "a").build(),
+        OutputsBuilder().add_output(Var(name="b")).build(),
+        set(),
+    ),
+    (
+        OutputsBuilder().add_output(Var(name="a"), "b").build(),
+        OutputsBuilder().add_output(Var(name="b")).build(),
+        {"b"},
+    ),
+    (
+        OutputsBuilder().add_output(Var(name="a")).build(),
+        OutputsBuilder().add_output(Var(name="a")).build(),
+        {"a"},
+    ),
+]
+
+
+@pytest.mark.parametrize("a_outputs, b_outputs, same", VALIDATE_OUTPUT_MAPPING_CASES)
+def test_validate_output_mapping(
+    a_outputs: Outputs, b_outputs: Outputs, same: set[str]
+):
+    mod1 = Model(
+        name="mod1",
+        inputs=Inputs(),
+        outputs=a_outputs,
+    )
+    mod2 = Model(
+        name="mod2",
+        inputs=Inputs(),
+        outputs=b_outputs,
+    )
+    assert resolve_outputs_mapping([mod1, mod2]) == same
+    assert resolve_outputs_mapping([mod2, mod1]) == same
+
+
+def test_inputs():
+    var = Var(name="a")
+    inputs = InputsBuilder().add_input(var).build()
+    assert list(inputs.inputs()) == [var]
+    assert inputs.mapping() == {var.name: var.name}
+    assert inputs.resolve_name(var.name) == var.name
+    assert inputs.var(var.name) == var
+
+    a, a_alias = Var(name="a"), "b"
+    b, b_alias = Var(name="b"), "a"
+    inputs = InputsBuilder().add_input(a, a_alias).add_input(b, b_alias).build()
+    assert list(inputs.inputs()) == [a, b]
+    assert inputs.mapping() == {a.name: a_alias, b.name: b_alias}
+
+    assert inputs.resolve_name(a.name) == a_alias
+    assert inputs.resolve_name(b.name) == b_alias
+
+    assert inputs.var(a.name) == a
+    assert inputs.var(b.name) == b
+
+
+INPUTS_ALIAS_CASES = [
+    (
+        InputsBuilder().add_input(Var(name="a"), "b").build(),
+        Var(name="a"),
+        "b",
+    ),
+    (
+        InputsBuilder().add_input(Var(name="a")).add_alias("a", "b").build(),
+        Var(name="a"),
+        "b",
+    ),
+]
+
+
+@pytest.mark.parametrize("inputs, var, alias", INPUTS_ALIAS_CASES)
+def test_inputs_alias(inputs: Inputs, var: Var, alias: str):
+    assert list(inputs.inputs()) == [var]
+    assert inputs.mapping() == {var.name: alias}
+    assert inputs.resolve_name(var.name) == alias
+    assert inputs.var(var.name) == var
+
+
+def test_outputs():
+    var = Var(name="a")
+    outputs = OutputsBuilder().add_output(var).build()
+    assert list(outputs.outputs()) == [var]
+    assert outputs.mapping() == {"a": {"a"}}
+    assert list(outputs.names()) == ["a"]
+    assert outputs.resolve_var(var.name) == var
+
+    var, alias = Var(name="a"), "b"
+    outputs = OutputsBuilder().add_output(var, alias).build()
+    assert list(outputs.outputs()) == [var]
+    assert outputs.mapping() == {"a": {"a", "b"}}
+    assert list(outputs.names()) == ["a", "b"]
+    assert outputs.resolve_var(var.name) == var
+    assert outputs.resolve_var(alias) == var
+
+
+def test_outputs_multi_with_alias():
+    var_a, b = Var(name="a"), "b"
+    var_c, d = Var(name="c"), "d"
+    outputs = OutputsBuilder().add_output(var_a, b).add_output(var_c, d).build()
+    assert list(outputs.outputs()) == [var_a, var_c]
+    assert outputs.mapping() == {"a": {"a", "b"}, "c": {"c", "d"}}
+    assert sorted(list(outputs.names())) == ["a", "b", "c", "d"]
+
+    assert outputs.resolve_var(var_a.name) == var_a
+    assert outputs.resolve_var(b) == var_a
+
+    assert outputs.resolve_var(var_c.name) == var_c
+    assert outputs.resolve_var(d) == var_c
+
+
+def test_outputs_raises_duplicate_variable():
+    a, a_alias = Var(name="a"), "b"
+    b = Var(name="b")
+    with pytest.raises(KeyError, match="'b' already exists"):
+        OutputsBuilder().add_output(a, a_alias).add_output(b).build()
+
+
+def test_outputs_raises_duplicate_variable_by_alias():
+    a, a_alias = Var(name="a"), "b"
+    b, b_alias = Var(name="b"), "a"
+    builder = OutputsBuilder().add_output(a).add_output(b)
+    with pytest.raises(KeyError, match=f"'{a_alias}' already exists"):
+        builder.add_alias(a.name, a_alias)
+
+    with pytest.raises(KeyError, match=f"'{b_alias}' already exists"):
+        builder.add_alias(b.name, b_alias)
+
+
+def test_validate_input_mapping_simple():
+    via = "input"
+    forcing_var = Var(name=via)
+    forcing = Model(
+        name="forcing",
+        inputs=Inputs(),
+        outputs=OutputsBuilder().add_output(forcing_var).build(),
+    )
+
+    a_input_var = Var(name=via)
+    a = Model(
+        name="a",
+        inputs=InputsBuilder().add_input(a_input_var).build(),
+        outputs=OutputsBuilder().add_output(Var(name="output")).build(),
+    )
+    valid, unset = resolve_inputs_mapping(forcing, a)
+
+    assert len(unset) == 0
+
+    assert a.name() in valid
+    assert len(valid[a.name()]) == 1
+    mapping = valid[a.name()][0]
+    assert mapping.src.model == forcing.name()
+    assert mapping.dest.model == a.name()
+    assert mapping.src.var == forcing_var
+    assert mapping.dest.var == a_input_var
+    assert mapping.via == via
+    assert not mapping.is_src_alias()
+    assert not mapping.is_dest_alias()
+
+
+def build_model(
+    name: str, inputs: list[str | tuple[str, str]], outputs: list[str | tuple[str, str]]
+) -> Model:
+    inputs_bldr = InputsBuilder()
+    for input_name in inputs:
+        if isinstance(input_name, tuple):
+            input_name, alias = input_name
+            inputs_bldr.add_input(Var(name=input_name), alias)
+        else:
+            inputs_bldr.add_input(Var(name=input_name))
+
+    outputs_bldr = OutputsBuilder()
+    for output_name in outputs:
+        if isinstance(output_name, tuple):
+            output_name, alias = output_name
+            outputs_bldr.add_output(Var(name=output_name), alias)
+        else:
+            outputs_bldr.add_output(Var(name=output_name))
+
+    return Model(name=name, inputs=inputs_bldr.build(), outputs=outputs_bldr.build())
+
+
+def mapping_into_src_via_dest(mapping: VarMapping) -> tuple[str, str, str]:
+    return mapping.src.model, mapping.via, mapping.dest.model
+
+
+VALIDATE_INPUT_MAPPING_CASES = [
+    # case: select non-aliased
+    (
+        (
+            # model name, inputs, outputs
+            # tuple of inputs / outputs is name alias pair
+            ("_", list(), [("a", "b")]),
+            ("forcing", list(), ["a"]),
+            ("model", ["a"], list()),
+        ),
+        {
+            # src, via, dest
+            ("forcing", "a", "model"),
+        },
+    ),
+    # case: select non-aliased flip ordering
+    (
+        (
+            ("forcing", list(), ["output"]),
+            ("_", list(), [("output", "actual")]),
+            ("model", ["output"], list()),
+        ),
+        {
+            ("forcing", "output", "model"),
+        },
+    ),
+    # case: select using alias
+    (
+        (
+            ("_", list(), ["input"]),
+            ("forcing", list(), ["output"]),
+            ("model", [("input", "output")], list()),
+        ),
+        {
+            ("forcing", "output", "model"),
+        },
+    ),
+    # case: select using alias flip ordering
+    (
+        (
+            ("forcing", list(), ["output"]),
+            ("_", list(), ["input"]),
+            ("model", [("input", "output")], list()),
+        ),
+        {
+            ("forcing", "output", "model"),
+        },
+    ),
+    # case: select first non-aliased if all aliased
+    (
+        (
+            ("forcing", list(), [("output", "forcing_alias")]),
+            ("_", list(), [("output", "a_alias")]),
+            ("model", ["output"], list()),
+        ),
+        {
+            ("forcing", "output", "model"),
+        },
+    ),
+    # case: select non-aliased with alias present
+    (
+        (
+            ("forcing", list(), [("a", "b")]),
+            ("model", ["a"], list()),
+        ),
+        {
+            ("forcing", "a", "model"),
+        },
+    ),
+    # case: select non-aliased using aliased
+    (
+        (
+            ("forcing", list(), ["output"]),
+            ("_", list(), [("output", "actual")]),
+            ("model", [("input", "output")], list()),
+        ),
+        {
+            ("forcing", "output", "model"),
+        },
+    ),
+    # case: multi-input
+    (
+        (
+            ("forcing", list(), [("output", "output_alias")]),
+            (
+                "model",
+                [
+                    ("input", "output"),
+                    ("input_2", "output"),
+                    ("input_3", "output_alias"),
+                ],
+                list(),
+            ),
+        ),
+        {
+            ("forcing", "output", "model"),
+            ("forcing", "output_alias", "model"),
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("mods, validation", VALIDATE_INPUT_MAPPING_CASES)
+def test_validate_input_mapping_positive(
+    mods: list[tuple[str, list[str | tuple[str, str]], list[str | tuple[str, str]]]],
+    validation: set[tuple[str, str, str]],
+):
+    models: list[Model] = [
+        build_model(name, inputs, outputs) for (name, inputs, outputs) in mods
+    ]
+    valid, unset = resolve_inputs_mapping(*models)
+    assert len(valid) > 0
+    assert len(unset) == 0
+    for _, mappings in valid.items():
+        for mapping in mappings:
+            assert mapping_into_src_via_dest(mapping) in validation
+
+
+VALIDATE_INPUT_MAPPING_CASES_NEGATIVE = [
+    # case: no provider
+    (
+        (
+            # model name, inputs, outputs
+            # tuple of inputs / outputs is name alias pair
+            ("forcing", list(), ["output"]),
+            ("model", ["no_input"], list()),
+        ),
+        {
+            # model, var or alias
+            ("model", "no_input"),
+        },
+    ),
+    # case: no provider b.c. invalid alias
+    (
+        (
+            # model name, inputs, outputs
+            # tuple of inputs / outputs is name alias pair
+            ("forcing", list(), ["output"]),
+            ("model", [("output", "no_input")], list()),
+        ),
+        {
+            # model, var or alias
+            ("model", "output"),
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("mods, validation", VALIDATE_INPUT_MAPPING_CASES_NEGATIVE)
+def test_validate_input_mapping_negative(
+    mods: list[tuple[str, list[str | tuple[str, str]], list[str | tuple[str, str]]]],
+    validation: set[tuple[str, str, str]],
+):
+    models: list[Model] = [
+        build_model(name, inputs, outputs) for (name, inputs, outputs) in mods
+    ]
+    _, unset = resolve_inputs_mapping(*models)
+    assert len(unset) > 0
+
+    for model, vars in unset.items():
+        for var in vars:
+            assert (model, var.name) in validation


### PR DESCRIPTION
This PR introduces the `ngen.config.model_vars` module (open to changing the name, please make suggestions). The module introduces functions and abstractions for representing and resolving NextGen BMI module input and output variables. For example, this feature set enables representing a set of BMI modules and determining which outputs map to which inputs. Likewise, it enables validating that a set of modules' output variables are valid under the NextGen frameworks invariants.

See tests for example usage.

## `ngen.config` -- `0.3.0`
## Additions

- `ngen.config.model_vars` functions and abstractions for representing and resolving NextGen BMI module input and output variables. Functions of note are:
  - `resolve_model_inputs`: Returns the input mappings and missing inputs for a single model.
  - `resolve_inputs_mapping`: Returns the input mappings and missing inputs for a list of models (often, multi-bmi).
  - `resolve_outputs_mapping`: Returns the set of invalid output names / aliases for a list of models.


## Todos

- Property resolve inputs that originate from the previous time step.
- Bump `ngen.config` version before merging