### PR TITLE
feat: add plugin system

### DIFF
--- a/python/example_config.yaml
+++ b/python/example_config.yaml
@@ -62,6 +62,41 @@ general:
   # to the total number of iterations, and changing it unexpectedly across restarts may lead
   # to undesirable results
   iterations: 100
+  #
+  # Optional list of import paths to plugin modules.
+  # A plugin consists of a set of implemented and decorated function
+  # "specifications". ngen.cal will call registered plugin functions at
+  # specified times during the calibration process. Plugins are defined in a
+  # module as a set of functions or a class. Class based plugin instances are
+  # instantiated without any arguments. Below are the supported plugin function
+  # "specifications". Plugin functions / methods must be decorated with
+  # ngen.cal.hookimpl. See pluggy docs for more info. https://pluggy.readthedocs.io/en/stable/
+  #
+  # def ngen_cal_configure(config: General) -> None:
+  #   """
+  #   Called before calibration begins. This allow plugins to perform initial configuration.
+  #   """
+  # def ngen_cal_start() -> None:
+  #   """Called when first entering the calibration loop."""
+  # def ngen_cal_finish(exception: Exception | None) -> None:
+  #   """
+  #   Called after exiting the calibration loop.
+  #   Plugin implementations are guaranteed to be called even if an exception is
+  #   raised during the calibration loop.
+  #   `exception` will be non-none if an exception was raised during calibration.
+  #   """
+  # plugins:
+  #   # sourced from `some_plugin.py`
+  #   - "some_plugin"
+  #   # `Plugin` class in `some.py`
+  #   - "some.Plugin"
+  #
+  # Optional mapping that plugins can use for configuration.
+  # By convention, the name of the plugin should be used as top level key in
+  # the `plugin_settings` mapping.
+  # plugin_settings:
+  #   some_plugin:
+  #     setting_1: value_1
 
 #Describe the model parameters you want to use, valid for independent and uniform
 #ngen strategies

--- a/python/ngen_cal/setup.cfg
+++ b/python/ngen_cal/setup.cfg
@@ -29,6 +29,7 @@ packages = find_namespace:
 package_dir =
     =src
 install_requires =
+    pluggy
     pydantic<2
     pandas>=1.1.2
     geopandas

--- a/python/ngen_cal/src/ngen/cal/__init__.py
+++ b/python/ngen_cal/src/ngen/cal/__init__.py
@@ -1,3 +1,6 @@
+from typing_extensions import Final
+import pluggy
+
 # Monkey patch pydantic to allow schema serialization of PyObject types to string
 from pydantic import PyObject
 def pyobject_schema(cls, field_schema):
@@ -10,3 +13,7 @@ from .calibratable import Calibratable, Adjustable, Evaluatable
 from .calibration_set import CalibrationSet, UniformCalibrationSet
 from .meta import JobMeta
 from .plot import *
+
+PROJECT_SLUG: Final = "ngen.cal"
+
+hookimpl = pluggy.HookimplMarker(PROJECT_SLUG)

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -18,7 +18,7 @@ def ngen_cal_configure(config: General) -> None:
     Called before calibration begins.
     This allow plugins to perform initial configuration.
 
-    Plugins should configuration data should be provided using the
+    Plugins' configuration data should be provided using the
     `plugins_settings` field in the `ngen.cal` configuration file.
     By convention, the name of the plugin should be used as top level key in
     the `plugin_settings` dictionary.

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pluggy
+
+from ngen.cal import PROJECT_SLUG
+
+if TYPE_CHECKING:
+    from ngen.cal.configuration import General
+
+hookspec = pluggy.HookspecMarker(PROJECT_SLUG)
+
+
+@hookspec
+def ngen_cal_configure(config: General) -> None:
+    """
+    Called before calibration begins.
+    This allow plugins to perform initial configuration.
+
+    Plugins should configuration data should be provided using the
+    `plugins_settings` field in the `ngen.cal` configuration file.
+    By convention, the name of the plugin should be used as top level key in
+    the `plugin_settings` dictionary.
+    """
+    # NOTE: not sure if we should just provide `General.plugin_settings`?
+    #       likewise, not sure if we should also pass the `model_conf`?
+    #       i am not inclined to just add things to add things.
+    #       for now, lets stick with `General` config until we _need_ more.
+
+
+@hookspec
+def ngen_cal_start() -> None:
+    """Called when first entering the calibration loop."""
+
+
+@hookspec
+def ngen_cal_finish(exception: Exception | None) -> None:
+    """
+    Called after exiting the calibration loop.
+    Plugin implementations are guaranteed to be called even if an exception is
+    raised during the calibration loop.
+    `exception` will be non-none if an exception was raised during calibration.
+    """

--- a/python/ngen_cal/src/ngen/cal/_plugin_system.py
+++ b/python/ngen_cal/src/ngen/cal/_plugin_system.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from types import ModuleType
+from typing import TYPE_CHECKING, Callable
+
+from typing_extensions import assert_never
+
+if TYPE_CHECKING:
+    from pluggy import PluginManager
+
+import pluggy
+
+# see `_hookspec` module for available hooks
+from ngen.cal import PROJECT_SLUG, _hookspec
+
+
+def setup_plugin_manager(plugins: list[Callable | ModuleType]) -> PluginManager:
+    pm = pluggy.PluginManager(PROJECT_SLUG)
+    pm.add_hookspecs(_hookspec)
+
+    for plugin in plugins:
+        if isinstance(plugin, Callable):
+            pm.register(plugin())
+        elif isinstance(plugin, ModuleType):
+            pm.register(plugin)
+        else:
+            assert_never(plugin)
+
+    return pm

--- a/python/ngen_cal/src/ngen/cal/configuration.py
+++ b/python/ngen_cal/src/ngen/cal/configuration.py
@@ -1,20 +1,19 @@
-from __future__ import annotations #for pydnaitc 
+from __future__ import annotations #for pydnaitc
 
 import logging
 
 #Typing, datamodel
 from pydantic import BaseModel, Field, DirectoryPath
 from pathlib import Path
-from typing import Optional, Union
-try: #to get literal in python 3.7, it was added to typing in 3.8
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing_extensions import Literal
+from typing import Any, Dict, Optional, List, Union
+from types import ModuleType, FunctionType
 
 #local components for composing configuration
 from .strategy import Estimation, Sensitivity
 from .model import PosInt
 from .ngen import Ngen
+from .utils import PyObjectOrModule, type_as_import_string
 
 import logging
 logging.basicConfig(
@@ -39,6 +38,16 @@ class General(BaseModel):
     parameter_log_file: Optional[Path]
     objective_log_file: Optional[Path]
     random_seed: Optional[int]
+    plugins: List[PyObjectOrModule] = Field(default_factory=list)
+    plugin_settings: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+    class Config(BaseModel.Config):
+        # properly serialize plugins
+        json_encoders = {
+            type: type_as_import_string,
+            ModuleType: lambda mod: mod.__name__,
+            FunctionType: type_as_import_string,
+        }
 
 class NoModel(BaseModel):
     """

--- a/python/ngen_cal/src/ngen/cal/utils.py
+++ b/python/ngen_cal/src/ngen/cal/utils.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from os import getcwd, chdir
-from typing import TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
+from types import ModuleType
+from pydantic import errors as pydantic_errors
+from pydantic.validators import str_validator
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Any
+    from pydantic.typing import CallableGenerator
 
 @contextmanager
 def pushd(path: 'Path') -> None:
@@ -20,3 +27,67 @@ def pushd(path: 'Path') -> None:
     finally:
         #when finished, return to original working dir
         chdir(cwd)
+
+def import_from_string(path: str) -> Any:
+    """Import an object or module from a string."""
+    from importlib import import_module
+
+    path = path.strip(" ")
+
+    try:
+        return import_module(path)
+    except ImportError:
+        ...
+
+    try:
+        module_path, class_name = path.rsplit(".", 1)
+    except ValueError as e:
+        raise ImportError(f'"{path}" doesn\'t look like a module path') from e
+
+    module = import_module(module_path)
+    if not class_name:
+        return module
+    try:
+        return getattr(module, class_name)
+    except AttributeError as e:
+        raise ImportError(
+            f'Module "{module_path}" does not define a "{class_name}" attribute'
+        ) from e
+
+
+class PyObjectOrModule:
+    """
+    Pydantic field type representing an object (e.g. class or function) or module.
+    If given a string, this type will import the object or module using importlib.
+    """
+    validate_always = True
+
+    @classmethod
+    def __get_validators__(cls) -> CallableGenerator:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> Any:
+        if isinstance(value, (Callable, ModuleType)):
+            return value
+
+        try:
+            value = str_validator(value)
+        except pydantic_errors.StrError:
+            raise pydantic_errors.PyObjectError(
+                error_message="value is neither a valid import path nor a valid callable"
+            )
+
+        try:
+            return import_from_string(value)
+        except ImportError as e:
+            raise pydantic_errors.PyObjectError(error_message=str(e))
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        field_schema['type'] = 'string'
+
+def type_as_import_string(t: type) -> str:
+    import inspect
+    mod = inspect.getmodule(t)
+    return f"{mod.__name__}.{t.__qualname__}"

--- a/python/ngen_cal/tests/test_plugin_system.py
+++ b/python/ngen_cal/tests/test_plugin_system.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from types import ModuleType
+
+from ngen.cal import hookimpl
+from ngen.cal._plugin_system import setup_plugin_manager
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from ngen.cal.configuration import General
+
+
+def test_setup_plugin_manager():
+    import sys
+
+    # this will be used to load function hookimpl's
+    mod = sys.modules[__name__]
+    plugins = [mod, ClassBasedPlugin]
+
+    pm = setup_plugin_manager(plugins)
+
+    from ngen.cal import PROJECT_SLUG
+
+    assert pm.project_name == PROJECT_SLUG
+
+    assert len(pm.get_plugins()) == len(plugins)
+
+    def contains(plug: Callable | ModuleType) -> bool:
+        if isinstance(plug, ModuleType):
+            return plug in plugins
+        return plug.__class__ in plugins
+
+    plugs = list(filter(contains, pm.get_plugins()))
+    assert len(plugs) == len(plugins), f"expected len(plugs)={len(plugins)}, plugs={plugs}"
+
+
+@hookimpl
+def ngen_cal_configure(config: General) -> None: ...
+
+
+@hookimpl
+def ngen_cal_start() -> None:
+    """Called when first entering the calibration loop."""
+
+
+@hookimpl
+def ngen_cal_finish() -> None:
+    """Called after exiting the calibration loop."""
+
+
+class ClassBasedPlugin:
+    @hookimpl
+    def ngen_cal_configure(self, config: General) -> None: ...
+
+    @hookimpl
+    def ngen_cal_start(self) -> None:
+        """Called when first entering the calibration loop."""
+
+    @hookimpl
+    def ngen_cal_finish(self) -> None:
+        """Called after exiting the calibration loop."""

--- a/python/ngen_cal/tests/test_utils.py
+++ b/python/ngen_cal/tests/test_utils.py
@@ -1,0 +1,51 @@
+from types import ModuleType, FunctionType
+
+from ngen.cal.utils import PyObjectOrModule, type_as_import_string
+from pydantic import BaseModel
+
+
+class Foo(BaseModel):
+    mod: PyObjectOrModule
+
+    class Config(BaseModel.Config):
+        # properly serialize plugins
+        json_encoders = {
+            FunctionType: type_as_import_string,
+            type: type_as_import_string,
+            ModuleType: lambda mod: mod.__name__,
+        }
+
+
+def test_create_from_py_objs_and_mods():
+    import sys
+
+    mod = sys.modules[__name__]
+    assert Foo(mod=mod).mod == mod
+
+    def some_fn(): ...
+
+    assert Foo(mod=some_fn).mod == some_fn
+
+
+def test_create_from_str():
+    import sys
+
+    mod = sys.modules[__name__]
+    assert Foo(mod=__name__).mod == mod
+
+    import pathlib
+
+    assert Foo(mod="pathlib.Path").mod == pathlib.Path
+
+
+def test_serialize():
+    import sys
+
+    mod = sys.modules[__name__]
+    assert Foo(mod=mod).json() == f'{{"mod": "{__name__}"}}'
+
+    assert Foo(mod=str).json() == '{"mod": "builtins.str"}'
+
+
+def test_schema():
+    assert Foo.schema()["properties"]["mod"]["type"] == "string"


### PR DESCRIPTION
Add a plugin system that enables extending the functionality of `ngen.cal` without the need to change source code. 

A plugin consists of a set of _implemented_ `ngen.cal` plugin function "specifications" that `ngen.cal` will call at specified times during the calibration process. Plugins are defined in a module as a set of functions or a class. Plugins used during calibration are specified in an `ngen.cal` configuration file using an added `plugins` field under `general`. Plugins can utilize an added `plugin_settings` field in the configuration file to accept plugin specific configuration (also under `general`). This PR introduces the following plugin function "specifications":

```python
def ngen_cal_configure(config: General) -> None:
    """
    Called before calibration begins.
    This allow plugins to perform initial configuration.

    Plugins' configuration data should be provided using the
    `plugins_settings` field in the `ngen.cal` configuration file.
    By convention, the name of the plugin should be used as top level key in
    the `plugin_settings` dictionary.
    """

def ngen_cal_start() -> None:
    """Called when first entering the calibration loop."""

def ngen_cal_finish(exception: Exception | None) -> None:
    """
    Called after exiting the calibration loop.
    Plugin implementations are guaranteed to be called even if an exception is
    raised during the calibration loop.
    `exception` will be non-none if an exception was raised during calibration.
    """
```

A plugin can implement any or all of the `ngen.cal` plugin function "specifications". Plugins can be defined in a python module or as a python class and are provided to `ngen.cal` in `ngen.cal`'s configuration file. For example, the following module/ function based plugin example will print the total calibration time:

> [!NOTE]
> all plugin functions and methods must be decorated with `ngen.cal.hookimpl`. See [`pluggy`](https://pluggy.readthedocs.io/en/stable/) docs for more info.

```python
# file: ngen_cal_time_fn.py
from __future__ import annotations

from time import perf_counter
from ngen.cal import hookimpl

start = None

@hookimpl
def ngen_cal_start() -> None:
    """Called when first entering the calibration loop."""
    global start
    start = perf_counter()

@hookimpl
def ngen_cal_finish(exception: Exception | None) -> None:
    """Called after exiting the calibration loop."""
    global start
    if exception is not None:
        print(f"Exception: {exception} was raised during calibration")
    print(f"Calibration took: {perf_counter() - start}s")
```

The following class based plugin does the same as above, but using a class:

> [!NOTE]
> class based plugin instances are instantiated **without any arguments**.

```python
# file: ngen_cal_time_class.py
from __future__ import annotations

from time import perf_counter
from ngen.cal import hookimpl

class Timer:
    @hookimpl
    def ngen_cal_start(self) -> None:
        """Called when first entering the calibration loop."""
        self.start = perf_counter()

    @hookimpl
    def ngen_cal_finish(self, exception: Exception | None) -> None:
        """Called after exiting the calibration loop."""
        if exception is not None:
            print(f"Exception: {exception} was raised during calibration")
        print(f"Calibration took: {perf_counter() - self.start}s")
```

The above plugins could be specified in a `ngen.cal` configuration file as follows:

> [!IMPORTANT]  
> The fully qualified python `importlib` string path to the module / class must be given. In the following example, the `ngen.cal` configuration file is located in the same directory as the plugin modules.

```yaml
general:
  plugins:
    - "ngen_cal_time_fn"
    - "ngen_cal_time_class.Timer"
  # plugin settings go here
  # plugin_settings:
  # ... rest of config
```

This feature relies on [`pluggy`](https://pluggy.readthedocs.io/en/stable/), the plugin library used by projects like
`pytest`, to declare and interact with plugin "hooks." See their docs for more information and documentation.

closes: #108

## Additions

- Add a plugin system that enables extending the functionality of `ngen.cal` without the need to change source code (see #126 for info).