### PR TITLE
Gpkg support

### DIFF
--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -110,7 +110,7 @@ class NgenBase(ModelExec):
         shutil.copy(self.realization, str(self.realization)+'_original')
        
         #Read the catchment hydrofabric data
-        if(self.hydrofabric is not None):
+        if self.hydrofabric is not None:
             #Reading hydofabric from geopackage
             self._catchment_hydro_fabric = gpd.read_file(self.hydrofabric, layer='divides')
             self._catchment_hydro_fabric.set_index('divide_id', inplace=True)

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -6,6 +6,7 @@ except ImportError:
     from typing_extensions import Literal
 from pathlib import Path
 import logging
+import warnings
 #supress geopandas debug logs
 logging.disable(logging.DEBUG)
 import json
@@ -264,7 +265,7 @@ class NgenBase(ModelExec):
             except:
                 raise TypeError("hydrofabric must be a valid file path")
         if cats is not None or nex is not None or x is not None:
-            print("WARNING: GeoJSON support will be deprecated in a future release, use geopackage hydrofabric.")
+            warnings.warn("GeoJSON support will be deprecated in a future release, use geopackage hydrofabric.")
 
         return values
 

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -230,6 +230,37 @@ class NgenBase(ModelExec):
             raise ValueError("Must provide partitions if using parallel")
         return values
 
+    @root_validator(pre=True)
+    def validate_hydrofabic(cls, values: dict) -> dict:
+        """
+
+        Args:
+            values (dict): configuation values to check
+
+        Raises:
+            ValueError: If a geopackage hydrofabric or set of geojsons are not found
+
+        Returns:
+            dict: Valid configuration elements for hydrofabric requirements
+        """
+        hf: FilePath = values.get('hydrofabric')
+        cats: FilePath = values.get("catchments")
+        nex: FilePath = values.get("nexus")
+        x: FilePath = values.get("crosswalk")
+
+        if hf is None and cats is None and nex is None and x is None:
+            msg = "Must provide a geopackage input with the hydrofabric key"\
+                  "or proide catchment, nexus, and crosswalk geojson files."  
+            raise ValueError(msg)
+        if(hf is not None):
+            try:
+                p = Path(hf)
+                if not p.exists():
+                    raise
+            except:
+                raise TypeError("hydrofabric must be a valid file path")
+        return values
+
     def update_config(self, i: int, params: 'pd.DataFrame', id: str = None, path=Path("./")):
         """_summary_
 

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -256,7 +256,7 @@ class NgenBase(ModelExec):
                   "or proide catchment, nexus, and crosswalk geojson files."  
             raise ValueError(msg)
         
-        if(hf is not None):
+        if hf is not None:
             try:
                 p = Path(hf)
                 if not p.exists():

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -234,9 +234,11 @@ class NgenBase(ModelExec):
             raise ValueError("Must provide partitions if using parallel")
         return values
 
-    @root_validator(pre=True)
+    @root_validator()
     def validate_hydrofabic(cls, values: dict) -> dict:
         """
+        Validates hydrofabric information is provided either as (deprecated) GeoJSON
+        or (preferred) GeoPackage files.
 
         Args:
             values (dict): configuation values to check

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -252,6 +252,7 @@ class NgenBase(ModelExec):
             msg = "Must provide a geopackage input with the hydrofabric key"\
                   "or proide catchment, nexus, and crosswalk geojson files."  
             raise ValueError(msg)
+        
         if(hf is not None):
             try:
                 p = Path(hf)
@@ -259,6 +260,9 @@ class NgenBase(ModelExec):
                     raise
             except:
                 raise TypeError("hydrofabric must be a valid file path")
+        if cats is not None or nex is not None or x is not None:
+            print("WARNING: GeoJSON support will be deprecated in a future release, use geopackage hydrofabric.")
+
         return values
 
     def update_config(self, i: int, params: 'pd.DataFrame', id: str = None, path=Path("./")):

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -265,7 +265,7 @@ class NgenBase(ModelExec):
             except:
                 raise TypeError("hydrofabric must be a valid file path")
         if cats is not None or nex is not None or x is not None:
-            warnings.warn("GeoJSON support will be deprecated in a future release, use geopackage hydrofabric.")
+            warnings.warn("GeoJSON support will be deprecated in a future release, use geopackage hydrofabric.", DeprecationWarning)
 
         return values
 

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -121,7 +121,10 @@ class NgenBase(ModelExec):
             attributes = gpd.read_file(self.hydrofabric, layer="flowpath_attributes").set_index('id')
             self._x_walk = pd.Series( attributes[ ~ attributes['rl_gages'].isna() ]['rl_gages'] )
         else:
-            #Reading hydrofabric from legacy geosjon
+            # Legacy geojson support
+            assert self.catchments is not None, "missing geojson catchments file"      
+            assert self.nexus is not None, "missing geojson nexus file" 
+            assert self.crosswalk is not None, "missing crosswalk file"
             self._catchment_hydro_fabric = gpd.read_file(self.catchments)
             self._catchment_hydro_fabric = self._catchment_hydro_fabric.rename(columns=str.lower)
             self._catchment_hydro_fabric.set_index('id', inplace=True)


### PR DESCRIPTION
Support geopackage hydrofabric inputs.  This maintains compatibility with the old geo-json input for now, but will print a deprecation warning when trying to use them.

Note that all hydrofabric keys are now optional in the config, but either hydrofabric or the the 3 geoson need to be provided for validation to succeed.  If both hydrofabric and geojson are provided, the geojson will be silently ignored (other than the deprecation warning...) and the hydrofabric input key will be used to initialize the model.