### PR TITLE
Update to use t-route output in csv form

### DIFF
--- a/python/ngen_cal/src/ngen/cal/__init__.py
+++ b/python/ngen_cal/src/ngen/cal/__init__.py
@@ -8,12 +8,11 @@ def pyobject_schema(cls, field_schema):
 
 PyObject.__modify_schema__ = classmethod(pyobject_schema)
 
+PROJECT_SLUG: Final = "ngen.cal"
+hookimpl = pluggy.HookimplMarker(PROJECT_SLUG)
+
 from .configuration import General, Model
 from .calibratable import Calibratable, Adjustable, Evaluatable
 from .calibration_set import CalibrationSet, UniformCalibrationSet
 from .meta import JobMeta
 from .plot import *
-
-PROJECT_SLUG: Final = "ngen.cal"
-
-hookimpl = pluggy.HookimplMarker(PROJECT_SLUG)

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -8,6 +8,8 @@ from ngen.cal import PROJECT_SLUG
 
 if TYPE_CHECKING:
     from ngen.cal.configuration import General
+    from pandas import Series
+    from pathlib import Path
 
 hookspec = pluggy.HookspecMarker(PROJECT_SLUG)
 
@@ -42,3 +44,21 @@ def ngen_cal_finish(exception: Exception | None) -> None:
     raised during the calibration loop.
     `exception` will be non-none if an exception was raised during calibration.
     """
+
+class ModelHooks():
+    @hookspec(firstresult=True)
+    def ngen_cal_model_output(id: str | None) -> Series:
+        """
+            Called during each calibration iteration to provide the model output in the form
+            of a pandas Series, indexed by time.
+            Output series should be in units of cubic meters per second.
+        """
+
+    @hookspec
+    def ngen_cal_model_post_iteration(path: Path, iteration: int) -> None:
+        """
+            Called after each model iteration is completed and evaluated.
+            And before the next iteration is configured and started.
+            Currently called at the end of an Adjustable's check_point function
+            which writes out calibration/parameter state data each iteration.
+        """

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -56,7 +56,7 @@ class ModelHooks:
         """
 
     @hookspec
-    def ngen_cal_model_iteration_finish(self, info: JobMeta, iteration: int) -> None:
+    def ngen_cal_model_iteration_finish(self, iteration: int, info: JobMeta) -> None:
         """
             Called after each model iteration is completed and evaluated.
             And before the next iteration is configured and started.

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -46,7 +46,7 @@ def ngen_cal_finish(exception: Exception | None) -> None:
     `exception` will be non-none if an exception was raised during calibration.
     """
 
-class ModelHooks():
+class ModelHooks:
     @hookspec(firstresult=True)
     def ngen_cal_model_output(self, id: str | None) -> Series:
         """

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -8,6 +8,7 @@ from ngen.cal import PROJECT_SLUG
 
 if TYPE_CHECKING:
     from ngen.cal.configuration import General
+    from ngen.cal.meta import JobMeta
     from pandas import Series
     from pathlib import Path
 
@@ -47,7 +48,7 @@ def ngen_cal_finish(exception: Exception | None) -> None:
 
 class ModelHooks():
     @hookspec(firstresult=True)
-    def ngen_cal_model_output(id: str | None) -> Series:
+    def ngen_cal_model_output(self, id: str | None) -> Series:
         """
             Called during each calibration iteration to provide the model output in the form
             of a pandas Series, indexed by time.
@@ -55,7 +56,7 @@ class ModelHooks():
         """
 
     @hookspec
-    def ngen_cal_model_post_iteration(path: Path, iteration: int) -> None:
+    def ngen_cal_model_iteration_finish(self, info: JobMeta, iteration: int) -> None:
         """
             Called after each model iteration is completed and evaluated.
             And before the next iteration is configured and started.

--- a/python/ngen_cal/src/ngen/cal/calibratable.py
+++ b/python/ngen_cal/src/ngen/cal/calibratable.py
@@ -92,13 +92,6 @@ class Adjustable(ABC):
         """
         self._df = read_parquet(path/self.check_point_file)
 
-    @abstractmethod
-    def save_output(self, i: int) -> None:
-        """
-            Save the last output of the runtime for iteration i
-        """
-        pass
-
     def restart(self) -> None:
             self.load_df('./')
 

--- a/python/ngen_cal/src/ngen/cal/calibratable.py
+++ b/python/ngen_cal/src/ngen/cal/calibratable.py
@@ -83,7 +83,7 @@ class Adjustable(ABC):
         """
         return Path('{}_parameter_df_state.parquet'.format(self.id))
 
-    def check_point(self, info: JobMeta, iteration: int) -> None:
+    def check_point(self, iteration: int, info: JobMeta) -> None:
         """
             Save calibration information
         """

--- a/python/ngen_cal/src/ngen/cal/calibratable.py
+++ b/python/ngen_cal/src/ngen/cal/calibratable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from pandas import Series, read_parquet # type: ignore
 from typing import Optional, TYPE_CHECKING
@@ -8,7 +10,8 @@ if TYPE_CHECKING:
     from pathlib import Path
     from datetime import datetime
     from typing import Tuple, Callable, Optional
-    from .model import EvaluationOptions
+    from ngen.cal.model import EvaluationOptions
+    from ngen.cal.meta import JobMeta
 
 class Adjustable(ABC):
     """
@@ -80,10 +83,11 @@ class Adjustable(ABC):
         """
         return Path('{}_parameter_df_state.parquet'.format(self.id))
 
-    def check_point(self, path: 'Path', iteration: int) -> None:
+    def check_point(self, info: JobMeta, iteration: int) -> None:
         """
             Save calibration information
         """
+        path = info.workdir
         self.df.to_parquet(path/self.check_point_file)
 
     def load_df(self, path: 'Path') -> None:

--- a/python/ngen_cal/src/ngen/cal/calibratable.py
+++ b/python/ngen_cal/src/ngen/cal/calibratable.py
@@ -80,7 +80,7 @@ class Adjustable(ABC):
         """
         return Path('{}_parameter_df_state.parquet'.format(self.id))
 
-    def check_point(self, path: 'Path') -> None:
+    def check_point(self, path: 'Path', iteration: int) -> None:
         """
             Save calibration information
         """

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -59,10 +59,10 @@ class CalibrationSet(Evaluatable):
             #is coded right now =(
             #would be better to hook this from the model object???
             #read the routed flow at the eval_nexus
-            df = pd.read_hdf(self._output_file)
+            df = pd.read_csv(self._output_file, index_col=0)
             df.index = df.index.map(lambda x: 'wb-'+str(x))
-            df.columns = pd.MultiIndex.from_tuples(df.columns)
-
+            tuples = [ eval(x) for x in df.columns ]
+            df.columns = pd.MultiIndex.from_tuples(tuples)
             # TODO should contributing_catchments be singular??? assuming it is for now...
             df = df.loc[self._eval_nexus.contributing_catchments[0].replace('cat', 'wb')]
             self._output = df.xs('q', level=1, drop_level=False)

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -33,8 +33,7 @@ class CalibrationSet(Evaluatable):
         self._eval_nexus = eval_nexus
         self._adjustables = adjustables
         # record the hooks needed for output and checkpointing
-        self._output_hook = hooks.ngen_cal_model_output
-        self._iteration_finish_hook = hooks.ngen_cal_model_iteration_finish
+        self._hooks = hooks
 
         #use the nwis location to get observation data
         obs =self._eval_nexus._hydro_location.get_data(start_time, end_time)
@@ -63,7 +62,7 @@ class CalibrationSet(Evaluatable):
         """
         # TODO should contributing_catchments be singular??? assuming it is for now...
         # Call output hooks, take first non-none result provided from hooks (called in LIFO order of registration)
-        df = self._output_hook(id=self._eval_nexus.contributing_catchments[0].replace('cat', 'wb'))
+        df = self._hooks.ngen_cal_model_output(id=self._eval_nexus.contributing_catchments[0].replace('cat', 'wb'))
         if not df:
             # list of results is empty
             print("No suitable output found from output hooks...")
@@ -102,7 +101,7 @@ class CalibrationSet(Evaluatable):
         for adjustable in self.adjustables:
             adjustable.df.to_parquet(info.workdir/adjustable.check_point_file)
         # call any model post hooks
-        self._iteration_finish_hook(info = info, iteration = iteration)
+        self._hooks.ngen_cal_model_iteration_finish(info = info, iteration = iteration)
 
     def restart(self) -> int:
         try:

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -137,14 +137,6 @@ class UniformCalibrationSet(CalibrationSet, Adjustable):
         """
         return self._id
 
-    def save_output(self, i) -> None:
-        """
-            Save the last output to output for iteration i
-        """
-        #FIXME ensure _output_file exists
-        #FIXME re-enable this once more complete
-        shutil.move(self._output_file, '{}_last'.format(self._output_file))
-    
     #update handled in meta, TODO remove this method???
     def update_params(self, iteration: int) -> None:
         pass

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -28,8 +28,9 @@ class CalibrationSet(Evaluatable):
         super().__init__(eval_params)
         self._eval_nexus = eval_nexus
         self._adjustables = adjustables
-        # record the hooks needed for output
+        # record the hooks needed for output and checkpointing
         self._output_hook = hooks.ngen_cal_model_output
+        self._post_hook = hooks.ngen_cal_model_post_iteration
 
         #use the nwis location to get observation data
         obs =self._eval_nexus._hydro_location.get_data(start_time, end_time)
@@ -96,6 +97,8 @@ class CalibrationSet(Evaluatable):
         """
         for adjustable in self.adjustables:
             adjustable.df.to_parquet(path/adjustable.check_point_file)
+        # call any model post hooks
+        self._post_hook(path = path, iteration = iteration)
 
     def restart(self) -> int:
         try:

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -94,7 +94,7 @@ class CalibrationSet(Evaluatable):
     def observed(self, df):
         self._observed = df
 
-    def check_point(self, info: JobMeta, iteration: int) -> None:
+    def check_point(self, iteration: int, info: JobMeta) -> None:
         """
             Save calibration information
         """

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -101,7 +101,7 @@ class CalibrationSet(Evaluatable):
         for adjustable in self.adjustables:
             adjustable.df.to_parquet(info.workdir/adjustable.check_point_file)
         # call any model post hooks
-        self._hooks.ngen_cal_model_iteration_finish(info = info, iteration = iteration)
+        self._hooks.ngen_cal_model_iteration_finish(iteration = iteration, info = info)
 
     def restart(self) -> int:
         try:

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -7,9 +7,9 @@ import pandas as pd
 if TYPE_CHECKING:
     from pandas import DataFrame
     from pathlib import Path
-    from pluggy import HookRelay
     from datetime import datetime
     from typing import Tuple, Optional
+    from ngen.cal._hookspec import ModelHooks
     from ngen.cal.model import EvaluationOptions
     from ngen.cal.meta import JobMeta
 
@@ -25,7 +25,7 @@ class CalibrationSet(Evaluatable):
         A HY_Features based catchment with additional calibration information/functionality
     """
 
-    def __init__(self, adjustables: Sequence[Adjustable], eval_nexus: Nexus, hooks: 'HookRelay', start_time: str, end_time: str, eval_params: 'EvaluationOptions'):
+    def __init__(self, adjustables: Sequence[Adjustable], eval_nexus: Nexus, hooks: ModelHooks, start_time: str, end_time: str, eval_params: 'EvaluationOptions'):
         """
 
         """
@@ -117,7 +117,7 @@ class UniformCalibrationSet(CalibrationSet, Adjustable):
         A HY_Features based catchment with additional calibration information/functionality
     """
 
-    def __init__(self, eval_nexus: Nexus, hooks: 'HookRelay', start_time: str, end_time: str, eval_params: 'EvaluationOptions', params: dict = {}):
+    def __init__(self, eval_nexus: Nexus, hooks: ModelHooks, start_time: str, end_time: str, eval_params: 'EvaluationOptions', params: dict = {}):
         """
 
         """

--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -90,15 +90,7 @@ class CalibrationSet(Evaluatable):
     def observed(self, df):
         self._observed = df
 
-    def save_output(self, i) -> None:
-        """
-            Save the last output to output for iteration i
-        """
-        #FIXME ensure _output_file exists
-        #FIXME re-enable this once more complete
-        shutil.move(self._output_file, '{}_last'.format(self._output_file))
-    
-    def check_point(self, path: 'Path') -> None:
+    def check_point(self, path: 'Path', iteration: int) -> None:
         """
             Save calibration information
         """

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -22,7 +22,7 @@ from .model import ModelExec, PosInt, Configurable
 from .parameter import Parameter, Parameters
 from .calibration_cathment import CalibrationCatchment, AdjustableCatchment
 from .calibration_set import CalibrationSet, UniformCalibrationSet
-from .ngen_hooks.ngen_output import TrouteOutput
+from .ngen_hooks.ngen_output import TrouteOutput, NgenSaveOutput
 #HyFeatures components
 from hypy.hydrolocation import NWISLocation # type: ignore
 from hypy.nexus import Nexus # type: ignore
@@ -111,6 +111,7 @@ class NgenBase(ModelExec):
         #now we work ours
         # Register the default ngen output hook
         self._plugin_manager.register(TrouteOutput(self.routing_output))
+        self._plugin_manager.register(NgenSaveOutput())
         #Make a copy of the config file, just in case
         shutil.copy(self.realization, str(self.realization)+'_original')
        

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -81,7 +81,7 @@ class NgenBase(ModelExec):
     nexus: Optional[FilePath]
     crosswalk: Optional[FilePath]
     ngen_realization: Optional[NgenRealization]
-    routing_output: Optional[Path] = Field(default=Path("flowveldepth_Ngen.h5"))
+    routing_output: Optional[Path] = Field(default=Path("flowveldepth_Ngen.csv"))
     #optional fields
     partitions: Optional[FilePath]
     parallel: Optional[PosInt]
@@ -298,6 +298,11 @@ class NgenBase(ModelExec):
             module.model_params = p[str(i)].to_dict()
         with open(path/self.realization.name, 'w') as fp:
                 fp.write( self.ngen_realization.json(by_alias=True, exclude_none=True, indent=4))
+        # Cleanup any t-route parquet files between runs
+        # TODO this may not be _the_ best place to do this, but for now,
+        # it works, so here it be...
+        for file in Path(path).glob("*NEXOUT.parquet"):
+            file.unlink()
     
 class NgenExplicit(NgenBase):
     

--- a/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
+++ b/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
@@ -55,3 +55,29 @@ class TrouteOutput():
             return None
         except Exception as e:
             raise(e)
+
+class NgenSaveOutput():
+
+    runoff_pattern = "cat-*.csv"
+    lateral_pattern = "nex-*.csv"
+    terminal_pattern = "tnx-*.csv"
+    coastal_pattern = "cnx-*.csv"
+    routing_output = "flowveldepth_Ngen.csv"
+    @hookimpl(trylast=True)
+    def ngen_cal_model_post_iteration(self, path: Path, iteration: int) -> None:
+        """
+            After each iteration, copy the old outputs for possible future
+            evaluation and inspection.
+        """
+        out_dir = path/f"output_{iteration}"
+        Path.mkdir(out_dir)
+        globs = []
+        globs.append( path.glob(self.runoff_pattern) )
+        globs.append( path.glob(self.lateral_pattern) )
+        globs.append( path.glob(self.terminal_pattern) )
+        globs.append( path.glob(self.coastal_pattern) )
+        for g in globs:
+            for f in g:
+                f.rename(out_dir/f.name)
+        rpath = path/Path(self.routing_output)
+        rpath.rename(out_dir/rpath.name)

--- a/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
+++ b/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 from ngen.cal import hookimpl
 
 import pandas as pd
 from pandas import DataFrame, Series
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ngen.cal.meta import JobMeta
 
 class TrouteOutput():
 
@@ -64,11 +70,12 @@ class NgenSaveOutput():
     coastal_pattern = "cnx-*.csv"
     routing_output = "flowveldepth_Ngen.csv"
     @hookimpl(trylast=True)
-    def ngen_cal_model_post_iteration(self, path: Path, iteration: int) -> None:
+    def ngen_cal_model_iteration_finish(self, info: JobMeta, iteration: int) -> None:
         """
             After each iteration, copy the old outputs for possible future
             evaluation and inspection.
         """
+        path = info.workdir
         out_dir = path/f"output_{iteration}"
         Path.mkdir(out_dir)
         globs = []

--- a/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
+++ b/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ngen.cal.meta import JobMeta
 
-class TrouteOutput():
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ngen.cal.meta import JobMeta
+
+class TrouteOutput:
 
     def __init__(self, filepath: Path) -> None:
         self._output_file = filepath
@@ -38,7 +43,7 @@ class TrouteOutput():
     # Try external provided output hooks, if those fail, try this one
     # this will only execute if all other hooks return None (or they don't exist)
     @hookimpl(specname="ngen_cal_model_output", trylast=True)    
-    def getOutput(self, id: str) -> Series:
+    def get_output(self, id: str) -> Series:
         try:
             #look for routed data
             #read the routed flow at the given id

--- a/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
+++ b/python/ngen_cal/src/ngen/cal/ngen_hooks/ngen_output.py
@@ -75,7 +75,7 @@ class NgenSaveOutput():
     coastal_pattern = "cnx-*.csv"
     routing_output = "flowveldepth_Ngen.csv"
     @hookimpl(trylast=True)
-    def ngen_cal_model_iteration_finish(self, info: JobMeta, iteration: int) -> None:
+    def ngen_cal_model_iteration_finish(self, iteration: int, info: JobMeta) -> None:
         """
             After each iteration, copy the old outputs for possible future
             evaluation and inspection.

--- a/python/ngen_cal/src/ngen/cal/search.py
+++ b/python/ngen_cal/src/ngen/cal/search.py
@@ -125,7 +125,7 @@ def dds(start_iteration: int, iterations: int,  calibration_object: 'Evaluatable
             _execute(agent)
         with pushd(agent.job.workdir):
             _evaluate(0, calibration_object, info=True)
-        calibration_object.check_point(agent.job.workdir, 0)
+        calibration_object.check_point(agent.job, 0)
         start_iteration += 1
 
     for i in range(start_iteration, iterations+1):
@@ -175,7 +175,7 @@ def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
                 _execute(agent)
             with pushd(agent.job.workdir):
                 _evaluate(0, calibration_set, info=True)
-            calibration_set.check_point(agent.job.workdir, 0)
+            calibration_set.check_point(agent.job, 0)
             start_iteration += 1
 
         for i in range(start_iteration, iterations+1):
@@ -188,7 +188,7 @@ def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
             _execute(agent)
             with pushd(agent.job.workdir):
                 _evaluate(i, calibration_set, info=True)
-            calibration_set.check_point(agent.job.workdir, i)
+            calibration_set.check_point(agent.job, i)
 
 def compute(calibration_object, iteration, input) -> float:
     params = input[0]
@@ -202,7 +202,7 @@ def compute(calibration_object, iteration, input) -> float:
         agent.update_config(iteration, calibration_object.df[[str(iteration), 'param', 'model']], calibration_object.id)
         _execute(agent)
         cost = _evaluate(iteration, calibration_object)
-        calibration_object.check_point(agent.workdir, iteration)
+        calibration_object.check_point(agent.job, iteration)
         #cost = _objective_func(calibration_object.output, calibration_object.observed, calibration_object.objective, calibration_object.evaluation_range)
     return cost
 

--- a/python/ngen_cal/src/ngen/cal/search.py
+++ b/python/ngen_cal/src/ngen/cal/search.py
@@ -125,7 +125,7 @@ def dds(start_iteration: int, iterations: int,  calibration_object: 'Evaluatable
             _execute(agent)
         with pushd(agent.job.workdir):
             _evaluate(0, calibration_object, info=True)
-        calibration_object.check_point(agent.job.workdir)
+        calibration_object.check_point(agent.job.workdir, 0)
         start_iteration += 1
 
     for i in range(start_iteration, iterations+1):
@@ -137,7 +137,7 @@ def dds(start_iteration: int, iterations: int,  calibration_object: 'Evaluatable
         _execute(agent)
         with pushd(agent.job.workdir):
             _evaluate(i, calibration_object, info=True)
-        calibration_object.check_point(agent.job.workdir)
+        calibration_object.check_point(agent.job.workdir, i)
 
 def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
     """
@@ -175,7 +175,7 @@ def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
                 _execute(agent)
             with pushd(agent.job.workdir):
                 _evaluate(0, calibration_set, info=True)
-            calibration_set.check_point(agent.job.workdir)
+            calibration_set.check_point(agent.job.workdir, 0)
             start_iteration += 1
 
         for i in range(start_iteration, iterations+1):
@@ -188,7 +188,7 @@ def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
             _execute(agent)
             with pushd(agent.job.workdir):
                 _evaluate(i, calibration_set, info=True)
-            calibration_set.check_point(agent.job.workdir)
+            calibration_set.check_point(agent.job.workdir, i)
 
 def compute(calibration_object, iteration, input) -> float:
     params = input[0]
@@ -202,7 +202,7 @@ def compute(calibration_object, iteration, input) -> float:
         agent.update_config(iteration, calibration_object.df[[str(iteration), 'param', 'model']], calibration_object.id)
         _execute(agent)
         cost = _evaluate(iteration, calibration_object)
-        calibration_object.check_point(agent.workdir)
+        calibration_object.check_point(agent.workdir, iteration)
         #cost = _objective_func(calibration_object.output, calibration_object.observed, calibration_object.objective, calibration_object.evaluation_range)
     return cost
 
@@ -272,7 +272,7 @@ def pso_search(start_iteration: int, iterations: int,  agent):
         #For pyswarm, DO NOT use the embedded multi-processing -- it is impossible to track the mapping of an agent to the params
         cost, pos = optimizer.optimize(cf, iters=iterations, n_processes=None)
         calibration_object.df.loc[:,'global_best'] = pos
-        calibration_object.check_point("./")
+        calibration_object.check_point("./", iterations)
         print("Best params with cost {}:".format(cost))
         print(calibration_object.df[['param','global_best']].set_index('param'))
     

--- a/python/ngen_cal/src/ngen/cal/search.py
+++ b/python/ngen_cal/src/ngen/cal/search.py
@@ -48,8 +48,6 @@ def _evaluate(i: int, calibration_object: 'Evaluatable', info=False) -> float:
 
     #read output and calculate objective_func
     score =  _objective_func(calibration_object.output, calibration_object.observed, calibration_object.objective, calibration_object.evaluation_range)
-    #save the calibration state, just in case
-    calibration_object.save_output(i)
     #update meta info based on latest score and write some log files
     calibration_object.update(i, score, log=True)
     if info:

--- a/python/ngen_cal/src/ngen/cal/search.py
+++ b/python/ngen_cal/src/ngen/cal/search.py
@@ -125,7 +125,7 @@ def dds(start_iteration: int, iterations: int,  calibration_object: 'Evaluatable
             _execute(agent)
         with pushd(agent.job.workdir):
             _evaluate(0, calibration_object, info=True)
-        calibration_object.check_point(agent.job, 0)
+        calibration_object.check_point(0, agent.job)
         start_iteration += 1
 
     for i in range(start_iteration, iterations+1):
@@ -137,7 +137,7 @@ def dds(start_iteration: int, iterations: int,  calibration_object: 'Evaluatable
         _execute(agent)
         with pushd(agent.job.workdir):
             _evaluate(i, calibration_object, info=True)
-        calibration_object.check_point(agent.job, i)
+        calibration_object.check_point(i, agent.job)
 
 def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
     """
@@ -175,7 +175,7 @@ def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
                 _execute(agent)
             with pushd(agent.job.workdir):
                 _evaluate(0, calibration_set, info=True)
-            calibration_set.check_point(agent.job, 0)
+            calibration_set.check_point(0, agent.job)
             start_iteration += 1
 
         for i in range(start_iteration, iterations+1):
@@ -188,7 +188,7 @@ def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
             _execute(agent)
             with pushd(agent.job.workdir):
                 _evaluate(i, calibration_set, info=True)
-            calibration_set.check_point(agent.job, i)
+            calibration_set.check_point(i, agent.job)
 
 def compute(calibration_object, iteration, input) -> float:
     params = input[0]
@@ -202,7 +202,7 @@ def compute(calibration_object, iteration, input) -> float:
         agent.update_config(iteration, calibration_object.df[[str(iteration), 'param', 'model']], calibration_object.id)
         _execute(agent)
         cost = _evaluate(iteration, calibration_object)
-        calibration_object.check_point(agent.job, iteration)
+        calibration_object.check_point(iteration, agent.job)
         #cost = _objective_func(calibration_object.output, calibration_object.observed, calibration_object.objective, calibration_object.evaluation_range)
     return cost
 
@@ -272,7 +272,7 @@ def pso_search(start_iteration: int, iterations: int,  agent):
         #For pyswarm, DO NOT use the embedded multi-processing -- it is impossible to track the mapping of an agent to the params
         cost, pos = optimizer.optimize(cf, iters=iterations, n_processes=None)
         calibration_object.df.loc[:,'global_best'] = pos
-        calibration_object.check_point(agent.job, iterations)
+        calibration_object.check_point(iterations, agent.job)
         print("Best params with cost {}:".format(cost))
         print(calibration_object.df[['param','global_best']].set_index('param'))
     

--- a/python/ngen_cal/src/ngen/cal/search.py
+++ b/python/ngen_cal/src/ngen/cal/search.py
@@ -137,7 +137,7 @@ def dds(start_iteration: int, iterations: int,  calibration_object: 'Evaluatable
         _execute(agent)
         with pushd(agent.job.workdir):
             _evaluate(i, calibration_object, info=True)
-        calibration_object.check_point(agent.job.workdir, i)
+        calibration_object.check_point(agent.job, i)
 
 def dds_set(start_iteration: int, iterations: int, agent: 'Agent'):
     """
@@ -272,7 +272,7 @@ def pso_search(start_iteration: int, iterations: int,  agent):
         #For pyswarm, DO NOT use the embedded multi-processing -- it is impossible to track the mapping of an agent to the params
         cost, pos = optimizer.optimize(cf, iters=iterations, n_processes=None)
         calibration_object.df.loc[:,'global_best'] = pos
-        calibration_object.check_point("./", iterations)
+        calibration_object.check_point(agent.job, iterations)
         print("Best params with cost {}:".format(cost))
         print(calibration_object.df[['param','global_best']].set_index('param'))
     

--- a/python/ngen_cal/tests/test_model.py
+++ b/python/ngen_cal/tests/test_model.py
@@ -60,7 +60,7 @@ def test_restart_1(ngen_config: 'Ngen', eval: 'EvaluationOptions', workdir: 'Dir
     eval.write_param_log_file(2)
     
     #make sure the catchment param df is saved before trying to restart
-    ngen_config.adjustables[0].check_point(workdir)
+    ngen_config.adjustables[0].check_point(workdir, 1)
 
     iteration = ngen_config.restart()
     assert iteration == 3

--- a/python/ngen_cal/tests/test_model.py
+++ b/python/ngen_cal/tests/test_model.py
@@ -61,7 +61,7 @@ def test_restart_1(ngen_config: 'Ngen', eval: 'EvaluationOptions', workdir: 'Dir
     eval.write_param_log_file(2)
     info = JobMeta(ngen_config.type, workdir, workdir = workdir)
     #make sure the catchment param df is saved before trying to restart
-    ngen_config.adjustables[0].check_point(info, 1)
+    ngen_config.adjustables[0].check_point(1, info)
 
     iteration = ngen_config.restart()
     assert iteration == 3

--- a/python/ngen_cal/tests/test_model.py
+++ b/python/ngen_cal/tests/test_model.py
@@ -1,6 +1,7 @@
 import pytest
 from typing import TYPE_CHECKING
 from ngen.cal.ngen import Ngen
+from ngen.cal.meta import JobMeta
 if TYPE_CHECKING:
     from ngen.cal.model import EvaluationOptions
     from pydantic import DirectoryPath
@@ -58,9 +59,9 @@ def test_restart_1(ngen_config: 'Ngen', eval: 'EvaluationOptions', workdir: 'Dir
     eval._best_params_iteration = "1"
     ngen_config.adjustables[0]._best_params = "1"
     eval.write_param_log_file(2)
-    
+    info = JobMeta(ngen_config.type, workdir, workdir = workdir)
     #make sure the catchment param df is saved before trying to restart
-    ngen_config.adjustables[0].check_point(workdir, 1)
+    ngen_config.adjustables[0].check_point(info, 1)
 
     iteration = ngen_config.restart()
     assert iteration == 3

--- a/python/ngen_cal/tests/test_plugin_system.py
+++ b/python/ngen_cal/tests/test_plugin_system.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from typing import Callable
 
     from ngen.cal.configuration import General
+    from pathlib import Path
 
 
 def test_setup_plugin_manager():
@@ -49,6 +50,13 @@ def ngen_cal_start() -> None:
 def ngen_cal_finish() -> None:
     """Called after exiting the calibration loop."""
 
+@hookimpl
+def ngen_cal_model_output() -> None:
+    """Test model output plugin"""
+
+@hookimpl
+def ngen_cal_model_post_iteration(path: Path, iteration: int) -> None:
+    """Test model post iteration"""
 
 class ClassBasedPlugin:
     @hookimpl
@@ -61,3 +69,11 @@ class ClassBasedPlugin:
     @hookimpl
     def ngen_cal_finish(self) -> None:
         """Called after exiting the calibration loop."""
+
+    @hookimpl
+    def ngen_cal_model_output(self) -> None:
+        """Test model output plugin"""
+
+    @hookimpl
+    def ngen_cal_model_post_iteration(self, path: Path, iteration: int) -> None:
+        """Test model post iteration"""


### PR DESCRIPTION
At some point t-route stopped supporting `flowveldepth` output in hdf5 form.  However, it will still output the `flowveldepth` in a csv file which can be used very similarly.  This PR updates routing output to support reading the csv output instead of hdf5.

Also, when multiple runs of t-route are used, a cleanup of the `*NEXOUT.parquet` files is needed, so that was added here in the `update_config` step to ensure a clean directory for each calibration iteration.

Only works once noaa-owp/t-route#788 is applied, otherwise t-route will still throw an error when run through ngen-cal since the working directory contains other, non-troute specific, parquet files (see noaa-owp/t-route#787)