### PR TITLE
fix / feat: handle building gpkg crosswalk from `flowpath-attributes`

### DIFF
--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -131,7 +131,7 @@ class NgenBase(ModelExec):
 
     @staticmethod
     def _is_legacy_gpkg_hydrofabric(hydrofabric: Path) -> bool:
-        """Return True if legacy hydrofabric."""
+        """Return True if legacy (<=v2.1) gpkg hydrofabric."""
         import sqlite3
         connection = sqlite3.connect(hydrofabric)
         # hydrofabric <= 2.1 use 'flowpaths'


### PR DESCRIPTION
Newer HF versions now use:
`flowlines` instead of `flowpaths`
`flowpath-attributes` instead of `flowpath_attributes`
`model-attributes` instead of `model_attributes`
This just adds support for that.

## Additions

- Add support for hydrofabrics that use `flowlines` and `flowpath-attributes`