### PR TITLE
fix: remapping cat -> wb. related to #141

### DIFF
--- a/python/ngen_cal/src/ngen/cal/calibration_set.py
+++ b/python/ngen_cal/src/ngen/cal/calibration_set.py
@@ -62,7 +62,10 @@ class CalibrationSet(Evaluatable):
         """
         # TODO should contributing_catchments be singular??? assuming it is for now...
         # Call output hooks, take first non-none result provided from hooks (called in LIFO order of registration)
-        df = self._hooks.ngen_cal_model_output(id=self._eval_nexus.contributing_catchments[0].replace('cat', 'wb'))
+        cat_id = self._eval_nexus.contributing_catchments[0].id
+        assert cat_id.startswith("cat"), f"expected catchment id to start with 'cat': {cat_id}"
+        cat_id = cat_id.replace("cat", "wb")
+        df = self._hooks.ngen_cal_model_output(id=cat_id)
         if df is None:
             # list of results is empty
             print("No suitable output found from output hooks...")


### PR DESCRIPTION
This fixes an issue uncovered after merging #141. Pre-141 we were, incorrectly, passing a `str` around when it was expected to be a `hypy.Catchment`. We were calling `str` methods on what should be and now is a `hypy.Catchment` instance. This resolves that issue.
