### PR TITLE
feat: `ngen_cal_model_observations` model plugin hook and default implementation

### DIFF
--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -134,9 +134,12 @@ class NgenBase(ModelExec):
 
     def _register_default_ngen_plugins(self):
         from .ngen_hooks.ngen_output import TrouteOutput
+        from .ngen_hooks.observations import UsgsObservations
 
         # t-route outputs
         self._plugin_manager.register(TrouteOutput(self.routing_output))
+        # observations
+        self._plugin_manager.register(UsgsObservations())
 
     @staticmethod
     def _is_legacy_gpkg_hydrofabric(hydrofabric: Path) -> bool:

--- a/python/ngen_cal/src/ngen/cal/ngen_hooks/observations.py
+++ b/python/ngen_cal/src/ngen/cal/ngen_hooks/observations.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import typing
+
+import pandas as pd
+from hypy.hydrolocation.nwis_location import NWISLocation
+
+from ngen.cal import hookimpl
+
+if typing.TYPE_CHECKING:
+    from datetime import datetime
+
+    from hypy.nexus import Nexus
+
+
+class UsgsObservations:
+    CFS_TO_CSM = 0.028316847
+    """ft**3/s to m**3/s"""
+
+    @hookimpl(trylast=True)
+    def ngen_cal_model_observations(
+        self,
+        nexus: Nexus,
+        start_time: datetime,
+        end_time: datetime,
+        simulation_interval: pd.Timedelta,
+    ) -> pd.Series:
+        # use the nwis location to get observation data
+        location = nexus._hydro_location
+        assert isinstance(location, NWISLocation), f"expected hypy.hydrolocation.NWISLocation instance, got {type(location)}. cannot retrieve observations"
+
+        try:
+            df = location.get_data(start=start_time, end=end_time)
+        except BaseException as e:
+            raise RuntimeError(f"failed to retrieve observations for usgs gage: {location.station_id}") from e
+
+        df.set_index("value_time", inplace=True)
+        ds = df["value"].resample(simulation_interval).nearest()
+        ds.rename("obs_flow", inplace=True)
+
+        # convert from CFS to CMS observations
+        ds = ds * UsgsObservations.CFS_TO_CSM
+        return ds

--- a/python/ngen_cal/tests/test_plugin_system.py
+++ b/python/ngen_cal/tests/test_plugin_system.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 from ngen.cal import hookimpl
 from ngen.cal._plugin_system import setup_plugin_manager
 
 if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
     from typing import Callable
 
+    import pandas as pd
+    from hypy.nexus import Nexus
+
     from ngen.cal.configuration import General
-    from pathlib import Path
 
 
 def test_setup_plugin_manager():
@@ -77,3 +81,13 @@ class ClassBasedPlugin:
     @hookimpl
     def ngen_cal_model_post_iteration(self, path: Path, iteration: int) -> None:
         """Test model post iteration"""
+
+    @hookimpl
+    def ngen_cal_model_observations(
+        self,
+        nexus: Nexus,
+        start_time: datetime,
+        end_time: datetime,
+        simulation_interval: pd.Timedelta,
+    ) -> pd.Series:
+        """Test observation plugin"""


### PR DESCRIPTION
`ngen_cal_model_observations` is called during each calibration iteration to provide truth / observation values in the form of a `pandas.Series`, indexed by time with a record every `simulation_interval`. The returned `pandas.Series` should be in units of cubic meters per second.

A default implementation is included in this PR the pulls data from the USGS NWIS IV data service using [`hydrotools.nwis_client`](https://github.com/NOAA-OWP/hydrotools/tree/main/python/nwis_client). This is enabled by default and does not require modifying configuration files.

Hook signature:

```python
class ModelHooks:
    @hookspec(firstresult=True)
    def ngen_cal_model_observations(
        self,
        id: str,
        start_time: datetime,
        end_time: datetime,
        simulation_interval: pd.Timedelta,
    ) -> pd.Series:
        """
        `id`: USGS gage station id
        `start_time`, `end_time`: inclusive simulation time range
        `simulation_interval`: time (distance) between simulation values
        """
```

Users who would like to load observation data from a file, for example, should implement this plugin hook and specify it as a `model` plugin in your `ngen.cal` configuration file. For example:

```python
# ngen_cal_observation_plugin.py
from __future__ import annotations

import pandas as pd
from ngen.cal import hookimpl

import typing
if typing.TYPE_CHECKING:
    from datetime import datetime

class NgenCalObservationPlugin:
    @hookimpl(trylast=True)
    def ngen_cal_model_observations(
        self,
        id: str,
        start_time: datetime,
        end_time: datetime,
        simulation_interval: pd.Timedelta,
    ) -> pd.Series:
        df = pd.read_csv("local_observations.csv")

        assert id in df["sites"].values, f"{id} not in {df['sites'].values}"
        df = df[(df["sites"] == id) && (df["time"] <= start_time ]

        df = df[(df["time"] >= start_time) && (df["time"] <= end_time)]

        df.set_index("time", inplace=True)

        ds = df["value"].resample(simulation_interval).nearest()
        return ds
```

Likewise, if you would like to, instead, save the observations used during calibration, you can implement this plugin as [a "wrapper" style plugin](https://pluggy.readthedocs.io/en/stable/#wrappers). For example:

```python
# ngen_cal_observation_writer_plugin.py
from __future__ import annotations

import pandas as pd
from ngen.cal import hookimpl

import typing
if typing.TYPE_CHECKING:
    from datetime import datetime

class NgenCalObservationWriterPlugin:
    @hookimpl(wrapper=True)
    def ngen_cal_model_observations(
        self,
        id: str,
        start_time: datetime,
        end_time: datetime,
        simulation_interval: pd.Timedelta,
    ) -> pd.Series | None:
        ds = yield
        if ds is None:
            return
        ds.to_csv(f"ngen_cal_observations-{id}.csv")
        return ds
```

Related to #93
Related to #111

## Additions

- `ngen_cal_model_observations` - called during each calibration iteration to provide truth / observation values in the form of a `pandas.Series`, indexed by time with a record every `simulation_interval`.