### PR TITLE
feat: `ngen_cal_model_configure` model hook

### DIFF
--- a/python/ngen_cal/src/ngen/cal/__main__.py
+++ b/python/ngen_cal/src/ngen/cal/__main__.py
@@ -57,6 +57,7 @@ def main(general: General, model_conf: Mapping[str, Any]):
 
     # setup plugins
     plugin_manager.hook.ngen_cal_configure(config=general)
+    model_inner._plugin_manager.hook.ngen_cal_model_configure(config=model_inner)
 
     print("Starting calib")
 

--- a/python/ngen_cal/src/ngen/cal/__main__.py
+++ b/python/ngen_cal/src/ngen/cal/__main__.py
@@ -57,7 +57,6 @@ def main(general: General, model_conf: Mapping[str, Any]):
 
     # setup plugins
     plugin_manager.hook.ngen_cal_configure(config=general)
-    model_inner._plugin_manager.hook.ngen_cal_model_configure(config=model_inner)
 
     print("Starting calib")
 
@@ -69,6 +68,10 @@ def main(general: General, model_conf: Mapping[str, Any]):
 
     # Initialize the starting agent
     agent = Agent(model, general.workdir, general.log, general.restart, general.strategy.parameters)
+
+    # Agent mutates the model config, so `ngen_cal_model_configure` is called afterwards
+    model_inner._plugin_manager.hook.ngen_cal_model_configure(config=model_inner)
+
     if general.strategy.algorithm == Algorithm.dds:
         func = dds_set #FIXME what about explicit/dds
         start_iteration = general.start_iteration

--- a/python/ngen_cal/src/ngen/cal/_hookspec.py
+++ b/python/ngen_cal/src/ngen/cal/_hookspec.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from hypy.nexus import Nexus
 
     from ngen.cal.configuration import General
+    from ngen.cal.model import ModelExec
     from ngen.cal.meta import JobMeta
 
 hookspec = pluggy.HookspecMarker(PROJECT_SLUG)
@@ -51,6 +52,19 @@ def ngen_cal_finish(exception: Exception | None) -> None:
 
 
 class ModelHooks:
+    @hookspec
+    def ngen_cal_model_configure(self, config: ModelExec) -> None:
+        """
+        Called before calibration begins.
+        This allow plugins to perform initial configuration.
+
+        Plugins' configuration data should be provided using the
+        `plugins_settings` field in the `model` section of an `ngen.cal`
+        configuration file.
+        By convention, the name of the plugin should be used as top level key in
+        the `plugin_settings` dictionary.
+        """
+
     @hookspec(firstresult=True)
     def ngen_cal_model_observations(
         self,

--- a/python/ngen_cal/src/ngen/cal/agent.py
+++ b/python/ngen_cal/src/ngen/cal/agent.py
@@ -85,6 +85,7 @@ class Agent(BaseAgent):
 
         if self._job is None:
             self._job = JobMeta(ngen_model.type, workdir, log=log)
+        ngen_model.workdir = self.job.workdir
         self._model.model.resolve_paths(self.job.workdir)
 
         self._params = parameters

--- a/python/ngen_cal/src/ngen/cal/agent.py
+++ b/python/ngen_cal/src/ngen/cal/agent.py
@@ -59,7 +59,7 @@ class BaseAgent(ABC):
 
 class Agent(BaseAgent):
 
-    def __init__(self, model: Model, workdir: 'Path', log: bool=False, restart: bool=False, parameters: 'Optional[Mapping[str, Any]]' = {}):
+    def __init__(self, model: Model, workdir: Path, log: bool=False, restart: bool=False, parameters: Mapping[str, Any] | None = {}):
         self._workdir = workdir
         self._job = None
         assert not isinstance(model.model, NoModel), "invariant"

--- a/python/ngen_cal/src/ngen/cal/agent.py
+++ b/python/ngen_cal/src/ngen/cal/agent.py
@@ -63,8 +63,9 @@ class Agent(BaseAgent):
         self._workdir = workdir
         self._job = None
         assert not isinstance(model.model, NoModel), "invariant"
-        # NOTE: if support for new models is added, this will need to be modified
-        model_inner = model.model.unwrap()
+        # NOTE: if support for new models is added, support for other model
+        # type variants will be required
+        ngen_model = model.model.unwrap()
         self._model = model
         if restart:
             # find prior ngen workdirs
@@ -76,14 +77,14 @@ class Agent(BaseAgent):
             # 0 correctly since not all basin params can be loaded.
             # There are probably some similar issues with explicit and independent, since they have
             # similar data semantics
-            workdirs = list(Path.glob(workdir, model_inner.type+"_*_worker"))
+            workdirs = list(Path.glob(workdir, ngen_model.type+"_*_worker"))
             if len(workdirs) > 1:
                 print("More than one existing workdir, cannot restart")
             elif len(workdirs) == 1:
-                self._job = JobMeta(model_inner.type, workdir, workdirs[0], log=log)
+                self._job = JobMeta(ngen_model.type, workdir, workdirs[0], log=log)
 
         if self._job is None:
-            self._job = JobMeta(model_inner.type, workdir, log=log)
+            self._job = JobMeta(ngen_model.type, workdir, log=log)
         self._model.model.resolve_paths(self.job.workdir)
 
         self._params = parameters

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -595,6 +595,11 @@ class Ngen(BaseModel, Configurable, smart_union=True):
         return self.__root__.get_binary()
     def update_config(self, *args, **kwargs):
         return self.__root__.update_config(*args, **kwargs)
+
+    def unwrap(self) -> NgenBase:
+        """convenience method that returns the underlying __root__ instance"""
+        return self.__root__
+
     #proxy methods for model
     @property
     def adjustables(self):

--- a/python/ngen_cal/tests/conftest.py
+++ b/python/ngen_cal/tests/conftest.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import json
 import pandas as pd # type: ignore
 import geopandas as gpd # type: ignore
-from ngen.cal.configuration import General
+from ngen.cal.configuration import General, Model
 from ngen.cal.ngen import Ngen
 from ngen.cal.meta import JobMeta
 from ngen.cal.calibration_cathment import CalibrationCatchment
@@ -104,9 +104,10 @@ def meta(ngen_config, general_config, mocker) -> Generator[JobMeta, None, None]:
     yield m
 
 @pytest.fixture
-def agent(ngen_config, general_config) -> Generator['Agent', None, None]:
-    a = Agent(ngen_config.__root__.dict(), general_config.workdir, general_config.log)
-    yield a
+def agent(ngen_config, general_config) -> Agent:
+    model = Model(model=ngen_config)
+    a = Agent(model, general_config.workdir, general_config.log)
+    return a
 
 @pytest.fixture
 def eval(ngen_config) -> Generator[EvaluationOptions, None, None]:

--- a/python/ngen_cal/tests/test_plugin_system.py
+++ b/python/ngen_cal/tests/test_plugin_system.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from hypy.nexus import Nexus
 
     from ngen.cal.configuration import General
+    from ngen.cal.model import ModelExec
+    from pathlib import Path
 
 
 def test_setup_plugin_manager():
@@ -73,6 +75,10 @@ class ClassBasedPlugin:
     @hookimpl
     def ngen_cal_finish(self) -> None:
         """Called after exiting the calibration loop."""
+
+    @hookimpl
+    def ngen_cal_model_configure(self, config: ModelExec) -> None:
+        """Test model model configure plugin"""
 
     @hookimpl
     def ngen_cal_model_output(self) -> None:


### PR DESCRIPTION
Add model hook: `ngen_cal_model_configure` hook that mirrors the existing `ngen_cal_configure` hook.

```python
    @hookspec
    def ngen_cal_model_configure(self, config: ngen.cal.model.ModelExec) -> None:
        """
        Called before calibration begins.
        This allow plugins to perform initial configuration.

        Plugins' configuration data should be provided using the
        `plugins_settings` field in the `model` section of an `ngen.cal`
        configuration file.
        By convention, the name of the plugin should be used as top level key in
        the `plugin_settings` dictionary.
        """
```
## Additions

- `ngen_cal_model_configure` model hook; Called before calibration begins. This allow plugins to perform initial configuration.
- `unwrap` method added to `ngen.cal.ngen.Ngen`. Returns the instance's `__root__` attribute.

## Changes

- `Agent` now takes a `Model` instance as a parameter. Previously, the raw config was passed.