### PR TITLE
Bump minimum supported `python>=3.8`

### DIFF
--- a/.github/workflows/ngen-conf.yml
+++ b/.github/workflows/ngen-conf.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ngen-init-config.yml
+++ b/.github/workflows/ngen-init-config.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/python/ngen_conf/setup.cfg
+++ b/python/ngen_conf/setup.cfg
@@ -18,9 +18,10 @@ classifiers =
     Intended Audience :: Education
     Intended Audience :: Science/Research
     License :: Free To Use But Restricted
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Hydrology
     Operating System :: OS Independent
 
@@ -33,7 +34,7 @@ install_requires =
     geojson_pydantic
     typing_extensions
     ngen_init_config[all] @ git+https://github.com/noaa-owp/ngen-cal@master#egg=ngen_init_config&subdirectory=python/ngen_init_config
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 
 [options.packages.find]

--- a/python/ngen_init_config/setup.cfg
+++ b/python/ngen_init_config/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
 install_requires =
     pydantic<2
     typing_extensions
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
See [python's end-of-life schedule](https://devguide.python.org/versions/#unsupported-versions).

`python 3.7` end-of-life was 2023-06-27. `python 3.8` end-of-life is on the horizon, but there are not plans at this time to remove support.

Closes #132

## `ngen.config`
## Changes

- Remove support for `python 3.7`


## `ngen.init_config`
## Changes

- Remove support for `python 3.7`
