### PR TITLE
Fix `PathPair` & `PathPairCollection` validation;  add `path_pair` type hint fn; use `path_pair` in `Topmodel` `init_config` model

### DIFF
--- a/python/ngen_conf/src/ngen/config/init_config/topmodel.py
+++ b/python/ngen_conf/src/ngen/config/init_config/topmodel.py
@@ -16,6 +16,7 @@ import typing_extensions
 from pydantic import Field, root_validator, validator
 
 import ngen.init_config.serializer_deserializer as serde
+from ngen.config.path_pair.path_pair import path_pair
 from ngen.config.path_pair import PathPair
 
 if TYPE_CHECKING:
@@ -353,8 +354,20 @@ class Topmodel(serde.GenericSerializerDeserializer):
     title: str
     # NOTE: never used with ngen
     input: pathlib.Path = pathlib.Path("/dev/null")
-    subcat: PathPair[TopModelSubcat]
-    params: PathPair[TopModelParams]
+    if TYPE_CHECKING:
+        subcat: PathPair[TopModelSubcat]
+        params: PathPair[TopModelParams]
+    else:
+        subcat: path_pair(
+            TopModelSubcat,
+            serializer=lambda o: o.to_str().encode(),
+            deserializer=TopModelSubcat.parse_obj,
+        )
+        params: path_pair(
+            TopModelParams,
+            serializer=lambda o: o.to_str().encode(),
+            deserializer=TopModelParams.parse_obj,
+        )
     output: pathlib.Path = pathlib.Path("/dev/null")
     hyd: pathlib.Path = pathlib.Path("/dev/null")
 

--- a/python/ngen_conf/src/ngen/config/init_config/topmodel.py
+++ b/python/ngen_conf/src/ngen/config/init_config/topmodel.py
@@ -381,22 +381,19 @@ class Topmodel(serde.GenericSerializerDeserializer):
             )
         return value
 
-    @root_validator
-    @classmethod
-    def _coerce_path_pairs(cls, values: dict[str, Any]) -> dict[str, Any]:
-        assert isinstance(values["subcat"], PathPair)
-        assert isinstance(values["params"], PathPair)
-        values["subcat"] = PathPair(
-            pathlib.Path(values["subcat"]),
-            deserializer=TopModelSubcat.parse_obj,  # type: ignore
-            serializer=lambda o: o.to_str(),  # type: ignore
-        )  # type: ignore
-        values["params"] = PathPair(
-            pathlib.Path(values["params"]),
-            deserializer=TopModelParams.parse_obj,  # type: ignore
-            serializer=lambda o: o.to_str(),  # type: ignore
-        )  # type: ignore
-        return values
+    @validator("subcat", pre=True)
+    def _coerce_topmodel_subcat_into_pathpair(cls, value: Any) -> Any:
+        return cls._maybe_coerce_into_pathpair(TopModelSubcat, value)
+
+    @validator("params", pre=True)
+    def _coerce_topmodel_params_into_pathpair(cls, value: Any) -> Any:
+        return cls._maybe_coerce_into_pathpair(TopModelParams, value)
+
+    @staticmethod
+    def _maybe_coerce_into_pathpair(ty: type, value: Any) -> Any:
+        if isinstance(value, ty):
+            return PathPair[ty].with_object(value)
+        return value
 
     @typing_extensions.override
     @classmethod

--- a/python/ngen_conf/src/ngen/config/path_pair/_abc_mixins.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/_abc_mixins.py
@@ -64,7 +64,7 @@ class AbstractPathPairMixin(ABC, Generic[T]):
         """
 
     @abstractmethod
-    def read(self):
+    def read(self) -> bool:
         """
         Try to read the current path and deserialize into an inner encapsulated `T`. If an inner `T`
         already exists and it deserializes correctly, replace the inner `T` with the new instance.

--- a/python/ngen_conf/tests/test_init_config_models.py
+++ b/python/ngen_conf/tests/test_init_config_models.py
@@ -163,5 +163,43 @@ def test_topmodel_deserialize_and_serialize_linked_configs(
     assert model.subcat.read(), f"failed to deserialize from file {topmodel_subcat_config_path!s}"
     assert model.params.read(), f"failed to deserialize from file {topmodel_params_config_path!s}"
 
-    assert model.subcat.serialize() == topmodel_subcat_config
-    assert model.params.serialize() == topmodel_params_config
+    assert model.subcat.serialize() == topmodel_subcat_config.encode()
+    assert model.params.serialize() == topmodel_params_config.encode()
+
+def test_topmodel_initialize_fields_with_path_pair_instances(
+    topmodel_subcat_config: str,
+    topmodel_params_config: str,
+):
+    from ngen.config.path_pair import PathPair
+
+    subcat = TopModelSubcat.parse_obj(topmodel_subcat_config)
+    params = TopModelParams.parse_obj(topmodel_params_config)
+
+    model = Topmodel(
+        title="title",
+        subcat=PathPair[TopModelSubcat].with_object(subcat),
+        params=PathPair[TopModelParams].with_object(params),
+    )
+
+    assert model.subcat.inner is not None
+    assert model.subcat.inner == subcat
+    assert model.params.inner is not None
+    assert model.params.inner == params
+
+def test_topmodel_initialize_fields_with_non_path_pair_instances(
+    topmodel_subcat_config: str,
+    topmodel_params_config: str,
+):
+    subcat = TopModelSubcat.parse_obj(topmodel_subcat_config)
+    params = TopModelParams.parse_obj(topmodel_params_config)
+
+    model = Topmodel(
+        title="title",
+        subcat=subcat, # type: ignore
+        params=params # type: ignore
+    )
+
+    assert model.subcat.inner is not None
+    assert model.subcat.inner == subcat
+    assert model.params.inner is not None
+    assert model.params.inner == params


### PR DESCRIPTION
## `ngen.config`
## Additions

- `path_pair` type hint fn. Use this instead of `PathPair` (see Feature Details section in #183)
- `Topmodel` `subcat` and `param` fields can now be initialized with `TopModelSubcat` and `TopModelParams` instances respectively.

## Changes

- Fix `PathPair` & `PathPairCollection` model validation
- Use `path_pair` type hint function in `Topmodel` `init_config` model
- `AbstractPathPairMixin.read` return type hint correct to `bool`. Already returned `bool`, type hint was missing.


## Feature Details

`path_pair` type hint function:

In nearly all cases, this should be used as the pydantic model field type if the field is to be a `PathPair[T]`. This will ensure that the `PathPair[T]` instance has the specified `serializer`, `deserializer`, `reader`, and `writer`.

NOTE: if a `PathPair` instance is passed to a model field defined using this function during initialization of the model, any `serializer`, `deserializer`, `reader`, or `writer` on the `PathPair` instance will not be replaced by the inputs provided to this function.

NOTE: if a pydantic model's field type is defined using this function, it's `ModelField.type_` will be a `PathPairOptions`.

Example:

```python
import typing
import pydantic
from ngen.config.path_pair import (
    PathPair,
    pydantic_serializer,
    pydantic_deserializer,
)

class Model(pydantic.BaseModel):
    field: int

class Foo(pydantic.BaseModel):
    # make static type checkers happy
    if typing.TYPE_CHECKING:
        path: PathPair[Model]
    else:
        path: path_pair(
            Model,
            serializer=pydantic_serializer,
            deserializer=pydantic_deserializer(Model),
        )
```