### PR TITLE
Update `cfe`, `topmodel`, and `lgar` calibratable parmeters; `ngen.cal` python < 3.9 pin `fiona<1.10.0`

### DIFF
--- a/python/ngen_cal/setup.cfg
+++ b/python/ngen_cal/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     pydantic<2
     pandas>=1.1.2
     geopandas
+    fiona<1.10.0; python_version < "3.9"
     matplotlib
     hydrotools.metrics
     hydrotools.nwis_client

--- a/python/ngen_conf/src/ngen/config/cfe.py
+++ b/python/ngen_conf/src/ngen/config/cfe.py
@@ -25,7 +25,8 @@ class CFEParams(BaseModel):
     """
     Surface runoff parameter; REFKDT is a tuneable parameter that significantly
     impacts surface infiltration and hence the partitioning of total runoff into
-    surface and subsurface runoff. Increasing REFKDT decreases surface runoff
+    surface and subsurface runoff. Increasing REFKDT decreases surface runoff.
+    Only applicable when surface_water_partitioning_scheme is Schaake.
     """
     expon: Optional[float]
     """soil primary outlet coefficient"""
@@ -40,9 +41,15 @@ class CFEParams(BaseModel):
     klf: Optional[float]
     """Nash coefficient that determines the volume of lateral flow"""
     kinf_nash_surface: Optional[float]
-    """Storage fraction per hour that moves from Nash surface reservoirs to soil"""
+    """
+    Storage fraction per hour that moves from Nash surface reservoirs to soil.
+    Only applicable surface_runoff_scheme = NASH_CASCADE.
+    """
     retention_depth_nash_surface: Optional[float]
-    """Water retention depth threshold (only applied to the first reservoir)"""
+    """
+    Water retention depth threshold (only applied to the first reservoir)
+    Only applicable surface_runoff_scheme = NASH_CASCADE.
+    """
     a_xinanjiang_inflection_point_parameter: Optional[float]
     """Contributing area curve inflection point"""
     b_xinanjiang_shape_parameter: Optional[float]

--- a/python/ngen_conf/src/ngen/config/cfe.py
+++ b/python/ngen_conf/src/ngen/config/cfe.py
@@ -5,15 +5,65 @@ from pydantic import BaseModel, Field
 
 from .bmi_formulation import BMIC
 
+
 class CFEParams(BaseModel):
-    """Class for validating CFE Parameters
-    """
-    maxsmc: Optional[float]
+    """Class for validating CFE Parameters"""
+
+    b: Optional[float]
+    """Pore size distribution index"""
     satdk: Optional[float]
+    """Saturated hydraulic conductivity"""
+    satpsi: Optional[float]
+    """saturated capillary head"""
     slope: Optional[float]
-    bb: Optional[float]
-    multiplier: Optional[float]
+    """Linear scaling of "openness" of bottom drainage boundary"""
+    maxsmc: Optional[float]
+    """saturated soil moisture content"""
+    wltsmc: Optional[float]
+    """wilting point soil moisture content"""
+    refkdt: Optional[float]
+    """
+    Surface runoff parameter; REFKDT is a tuneable parameter that significantly
+    impacts surface infiltration and hence the partitioning of total runoff into
+    surface and subsurface runoff. Increasing REFKDT decreases surface runoff
+    """
     expon: Optional[float]
+    """soil primary outlet coefficient"""
+    max_gw_storage: Optional[float]
+    """Maximum groundwater storage"""
+    cgw: Optional[float]
+    """Coefficent for the groundwater equation"""
+    alpha_fc: Optional[float]
+    """field_capacity_atm_press_fraction (alpha_fc)"""
+    kn: Optional[float]
+    """Nash coefficient for subsurface lateral flow through Nash cascade"""
+    klf: Optional[float]
+    """Nash coefficient that determines the volume of lateral flow"""
+    kinf_nash_surface: Optional[float]
+    """Storage fraction per hour that moves from Nash surface reservoirs to soil"""
+    retention_depth_nash_surface: Optional[float]
+    """Water retention depth threshold (only applied to the first reservoir)"""
+    a_xinanjiang_inflection_point_parameter: Optional[float]
+    """Contributing area curve inflection point"""
+    b_xinanjiang_shape_parameter: Optional[float]
+    """Contributing area curve shape parameter"""
+    x_xinanjiang_shape_parameter: Optional[float]
+    """Contributing area curve shape parameter"""
+
+    class Config(BaseModel.Config):
+        allow_population_by_field_name = True
+        fields = {
+            "cgw": {"alias": "Cgw"},
+            "kn": {"alias": "Kn"},
+            "klf": {"alias": "Klf"},
+            "kinf_nash_surface": {"alias": "Kinf_nash_surface"},
+            "a_xinanjiang_inflection_point_parameter": {
+                "alias": "a_Xinanjiang_inflection_point_parameter"
+            },
+            "b_xinanjiang_shape_parameter": {"alias": "b_Xinanjiang_shape_parameter"},
+            "x_xinanjiang_shape_parameter": {"alias": "x_Xinanjiang_shape_parameter"},
+        }
+
 
 class CFE(BMIC):
     """A BMIC implementation for the CFE ngen module

--- a/python/ngen_conf/src/ngen/config/lgar.py
+++ b/python/ngen_conf/src/ngen/config/lgar.py
@@ -1,13 +1,58 @@
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Optional
+from pydantic import BaseModel, Field
 
 from .bmi_formulation import BMICxx
+
+
+class LgarParams(BaseModel):
+    smcmin: Optional[float]
+    """
+    residual volumetric water content
+    Unit: cm3/cm3
+    """
+    smcmax: Optional[float]
+    """
+    water content of the soil at natural saturation;
+    Unit: cm3/cm3
+    """
+    van_genuchten_alpha: Optional[float]
+    """
+    van Genuchten parameter related to inverse of air entry pressure
+    Unit: 1/cm
+    """
+    van_genuchten_n: Optional[float]
+    """
+    van Genuchten parameter related to pore size distribution
+    Unit: -
+    """
+    hydraulic_conductivity: Optional[float]
+    """
+    saturated hydraulic conductivity of the soil
+    Unit: cm/h
+    """
+    soil_depth_layers: Optional[float]
+    """
+    soil layer thickness
+    Unit: cm
+    """
+    ponded_depth_max: Optional[float]
+    """
+    maximum allowed ponded water depth
+    Unit: cm
+    """
+    field_capacity: Optional[float]
+    """
+    negative capillary head representing field capacity, used in reduction of PET to AET
+    Unit: cm
+    """
 
 
 class LGAR(BMICxx):
     """A BMIC++ implementation for LGAR module"""
 
+    model_params: Optional[LgarParams]
     registration_function: str = "none"
     main_output_variable: str = "precipitation_rate"
     model_name: str = Field("LGAR", const=True, alias="model_type_name")

--- a/python/ngen_conf/src/ngen/config/topmod.py
+++ b/python/ngen_conf/src/ngen/config/topmod.py
@@ -5,14 +5,44 @@ from pydantic import BaseModel, Field
 
 from .bmi_formulation import BMIC
 
+
 class TopmodParams(BaseModel):
-    """Class for validating Topmod Parameters
+    """Class for validating Topmod Parameters"""
+    szm: Optional[float]
+    """
+    Exponential scaling parameter for decline of transmissivity with increase in storage deficit
+    Unit: meters (m)
     """
     sr0: Optional[float]
+    """
+    initial root zone storage deficit
+    Unit: meters (m)
+    """
     srmax: Optional[float]
-    szm: Optional[float]
-    t0: Optional[float]
+    """
+    Maximum capacity of the root zone  (Available water capacity to plants)
+    Unit: meters (m)
+    """
     td: Optional[float]
+    """
+    Time delay for recharge to the saturated zone per unit of deficit
+    Unit: hours (h)
+    """
+    t0: Optional[float]
+    """
+    natural log of downslope transmissivity when the soil is just saturated to the surface (corresponds to transmissivities of 0.000335 and 2980.96 m/h)
+    Unit: meters per hour (m/h)
+    """
+    chv: Optional[float]
+    """
+    Average channel flow velocity
+    Unit: meters per hour (m/h)
+    """
+    rv: Optional[float]
+    """
+    Internal overland flow routing velocity
+    Unit: meters per hour (m/h)
+    """
 
 class Topmod(BMIC):
     """A BMIC implementation for the Topmod ngen module


### PR DESCRIPTION
## `ngen.config`
## Additions

- `LgarParams`
- docstrings for `CfeParams`, `TopmodelParams`, and `LgarParams` parameters
- New `CfeParams` and `TopmodelParams` calibratable parameters

## Removals

- `CfeParams` `bb` and `multiplier` fields dropped. `bb` is now `b`; support for `multiplier` was dropped in https://github.com/NOAA-OWP/cfe/pull/64

## `ngen.cal`

## Changes

- `ngen.cal` on `python` `3.9` pins `fiona<1.10.0` (see notes)


## Notes:

`fiona` `v1.10.0` deprecated  `fiona.path` field (seem to have been removed?) [see](https://github.com/Toblerity/Fiona/releases/tag/1.10.0).

`geopandas` `geojson` reader uses `fiona`.

`geopandas` `v0.14` dropped support for `python<3.9`. So, `ngen.cal` installations are effectively pinned to `geopandas<=0.14`. Transitively, `ngen.cal` needs to pin `fiona<1.10.0` for compatibility.
https://geopandas.org/en/stable/docs/changelog.html#version-0-14-sep-15-2023
