### PR TITLE
Param hotfix

### DIFF
--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -46,13 +46,22 @@ def _params_as_df(params: Mapping[str, Parameters], name: str = None):
             df['model'] = k
             df.rename(columns={'name':'param'}, inplace=True)
             dfs.append(df)
-        return pd.concat(dfs)
+        df = pd.concat(dfs)
+        # Copy the parameter column and use it as the index
+        # The param -> model relation has to be maintained for writing back
+        # to specific model components later
+        df['p'] = df['param']
+        return df.set_index('p')
     else:
         p = params.get(name, [])
         df = pd.DataFrame([s.__dict__ for s in p])
         df['model'] = name
         df.rename(columns={'name':'param'}, inplace=True)
-        return df
+        if p:
+            df['p'] = df['param']
+            return df.set_index('p')
+        else:
+            return df
 
 def _map_params_to_realization(params: Mapping[str, Parameters], realization: Realization):
     # don't even think about calibration multiple formulations at once just yet..

--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -64,7 +64,12 @@ def _params_as_df(params: Mapping[str, Parameters], name: str = None):
             return df
 
 def _map_params_to_realization(params: Mapping[str, Parameters], realization: Realization):
-    # don't even think about calibration multiple formulations at once just yet..
+    # Since params are mapped by model name, we can track the model/param relationship
+    # in the dataframe to reconstruct each models parameters indepndently
+    # with a unique parameter index build in _params_as_df, this supports multi-model
+    # parameters with a key distinction --
+    # WARNING parameters with the _exact_ same name between two models will be exposed
+    # as two parameters in the parameter space, but will always share the same value
     module = realization.formulations[0].params
 
     if isinstance(module, MultiBMI):


### PR DESCRIPTION
Previously, only single model parameter spaces were fully supported by ngen-cal.

This *feature* makes it possible to calibrate a multi-bmi model with ngen by allowing multiple parameter sets from different models to be combined into a single search space with a unique (ish) index.  

> [!NOTE]
> Parameters with the _exact_ same name between two models will be exposed as two parameters in the parameter space, but will always share the same value.