### PR TITLE
fix(py3.12): explicitly call `__init__` to setup `PurePath` instance

### DIFF
--- a/.github/workflows/ngen-cal.yaml
+++ b/.github/workflows/ngen-cal.yaml
@@ -15,11 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        #3.10 ends up building a lot of python deps as whls (e.g. pandas) and it takes a LONG time (11m42s)
-        #so for now, don't enable testing on 3.10.  3.11 similarly builds some deps, but it
-        #particaularly fails to build the tables dep since the ubuntu image doesn't have hdf5
-        #When 3.11 tables wheel is available, then add it?  Also, put 3.10 in quotes or it turns into 3.1
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ngen-conf.yml
+++ b/.github/workflows/ngen-conf.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ngen-init-config.yml
+++ b/.github/workflows/ngen-init-config.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
+++ b/python/ngen_conf/src/ngen/config/path_pair/path_pair.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path, PosixPath, WindowsPath
 
 from .protocol import Reader, Writer, Serializer, Deserializer
@@ -84,6 +85,9 @@ class PathPair(AbstractPathPairMixin[T], Path, Generic[T]):
             inner = _MaybeInner[cls._parameters[0]](inner=inner).inner  # type: ignore
         cls = WindowsPathPair[T] if os.name == "nt" else PosixPathPair[T]
         self: WindowsPathPair[T] | PosixPathPair[T] = Path.__new__(cls, *args, **kwargs)
+        # explicitly call __init__ to setup instance (see #193)
+        if sys.version_info >= (3, 12):
+            self.__init__(*args)
         self._inner = inner  # type: ignore
         self._serializer = serializer  # type: ignore
         self._deserializer = deserializer  # type: ignore
@@ -316,6 +320,9 @@ class PathPairCollection(AbstractPathPairCollectionMixin[T], Path, Generic[T]):
             deserializer=deserializer,
             **kwargs,
         )
+        # explicitly call __init__ to setup instance (see #193)
+        if sys.version_info >= (3, 12):
+            self.__init__(*args)
         self._inner = inner
         self._serializer = serializer
         self._deserializer = deserializer


### PR DESCRIPTION
Fixes #193.

See #193 for detail.