### PR TITLE
feat: `ngen.cal` optional post calibration `validation` run

### DIFF
--- a/python/ngen_cal/src/ngen/cal/ngen.py
+++ b/python/ngen_cal/src/ngen/cal/ngen.py
@@ -388,7 +388,16 @@ class NgenBase(ModelExec):
         # Cleanup any t-route parquet files between runs
         # TODO this may not be _the_ best place to do this, but for now,
         # it works, so here it be...
-        for file in Path(path).glob("*NEXOUT.parquet"):
+        import itertools
+        to_remove = (
+            # Path(path).glob("troute_output_*.*"),
+            # Path(path).glob("flowveldepth_*.*"),
+            Path(path).glob("*NEXOUT.parquet"),
+            # ngen files
+            # Path(path).glob("cat-*.csv"),
+            # Path(path).glob("nex-*_output.csv"),
+        )
+        for file in itertools.chain(*to_remove):
             file.unlink()
 
 class NgenExplicit(NgenBase):

--- a/python/ngen_cal/src/ngen/cal/search.py
+++ b/python/ngen_cal/src/ngen/cal/search.py
@@ -24,11 +24,14 @@ __iteration_counter = 0
 
 def _objective_func(simulated_hydrograph, observed_hydrograph, objective, eval_range: tuple[datetime, datetime] | None = None):
     df = pd.merge(simulated_hydrograph, observed_hydrograph, left_index=True, right_index=True)
-    if df.empty:
-        print("WARNING: Cannot compute objective function, do time indicies align?")
     if eval_range:
         df = df.loc[eval_range[0]:eval_range[1]]
-    #print( df )
+    if df.empty:
+        print("WARNING: Cannot compute objective function, do time indicies align?")
+        if eval_range:
+            print(f"\teval range: [{eval_range[0]!s} : {eval_range[1]!s}]")
+        print(f"\tsim interval: [{simulated_hydrograph.index.min()!s} : {simulated_hydrograph.index.max()!s}]")
+        print(f"\tobs interval: [{observed_hydrograph.index.min()!s} : {observed_hydrograph.index.max()!s}]")
     #Evaluate custom objective function providing simulated, observed series
     return objective(df['obs_flow'], df['sim_flow'])
 


### PR DESCRIPTION
NOTE: this needs to be refactored... and tested. This was pushed through just to get thing working will not affect the code around it if this feature is not used.

This feature enables running ngen with the best calibration parameters after calibration has completed. A validation interval is configurable under `model.val_params`. See `ngen.cal.model.ValidationOptions` for specifics.