### PR TITLE
update variable names to v2.2 data model

### DIFF
--- a/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
+++ b/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
@@ -65,8 +65,8 @@ class Cfe:
 
         # saturated hydraulic conductivity
         # NOTE: it seems all values each layer of `dksat_soil_layers_stag` are the same.
-        x_data = data.get("dksat_soil_layers_stag=1",None)
-        if x_data is None: x_data = data.get("geom_mean.dksat_soil_layers_stag=1",None)
+        x_data = data.get("geom_mean.dksat_soil_layers_stag=1",None)
+        if x_data is None: x_data = data.get("dksat_soil_layers_stag=1",None)
         if x_data is None: raise Exception(f"Neither geom_mean.dksat_soil_layers_stag=1 nor dksat_soil_layers_stag=1 were found in attributes")        
         self.data["soil_params_satdk"] = FloatUnitPair(
             value=x_data,
@@ -101,7 +101,7 @@ class Cfe:
 
         # wilting point soil moisture content
         # NOTE: it seems all values each layer of `smcwlt_soil_layers_stag` are the same.
-        x_data = data.get("mean.smcwlt_soil_layers_stag=1=1",None)
+        x_data = data.get("mean.smcwlt_soil_layers_stag=1",None)
         if x_data is None: x_data = data.get("smcwlt_soil_layers_stag=1",None)
         if x_data is None: raise Exception(f"Neither mean.smcwlt_soil_layers_stag=1 nor smcwlt_soil_layers_stag=1 were found in attributes")         
         self.data["soil_params_wltsmc"] = FloatUnitPair(
@@ -122,9 +122,9 @@ class Cfe:
         self.data["cgw"] = FloatUnitPair(value=x_data, unit=M_PER_H)
 
         # exponent parameter (1.0 for linear reservoir)
-        x_data = data.get("mean.Expon",None)
+        x_data = data.get("mode.Expon",None)
         if x_data is None: x_data = data.get("gw_Expon",None)
-        if x_data is None: raise Exception(f"Neither mean.Expon nor gw_Expon were found in attributes")         
+        if x_data is None: raise Exception(f"Neither mode.Expon nor gw_Expon were found in attributes")         
         self.data["expon"] = FloatUnitPair(value=x_data, unit=EMPTY)
 
     def _v2_defaults(self) -> None:

--- a/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
+++ b/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
@@ -55,50 +55,77 @@ class Cfe:
         """
         # beta exponent on Clapp-Hornberger (1978) soil water relations
         # NOTE: it seems all values each layer of `bexp_soil_layers_stag` are the same.
+        x_data = data.get("mode.bexp_soil_layers_stag=1",None)
+        if x_data is None: x_data = data.get("bexp_soil_layers_stag=1",None)
+        if x_data is None: raise Exception(f"Neither mode.bexp_soil_layers_stag=1 nor bexp_soil_layers_stag=1 were found in attributes")
         self.data["soil_params_b"] = FloatUnitPair(
-            value=data["mode.bexp_soil_layers_stag=1"],
+            value=x_data,
             unit=EMPTY,
         )
 
         # saturated hydraulic conductivity
         # NOTE: it seems all values each layer of `dksat_soil_layers_stag` are the same.
+        x_data = data.get("dksat_soil_layers_stag=1",None)
+        if x_data is None: x_data = data.get("geom_mean.dksat_soil_layers_stag=1",None)
+        if x_data is None: raise Exception(f"Neither geom_mean.dksat_soil_layers_stag=1 nor dksat_soil_layers_stag=1 were found in attributes")        
         self.data["soil_params_satdk"] = FloatUnitPair(
-            value=data["geom_mean.dksat_soil_layers_stag=1"],
+            value=x_data,
             unit=M_PER_S,
         )
 
         # saturated capillary head
         # NOTE: it seems all values each layer of `psisat_soil_layers_stag` are the same.
+        x_data = data.get("geom_mean.psisat_soil_layers_stag=1",None)
+        if x_data is None: x_data = data.get("psisat_soil_layers_stag=1",None)
+        if x_data is None: raise Exception(f"Neither geom_mean.psisat_soil_layers_stag=1 nor psisat_soil_layers_stag=1 were found in attributes")           
         self.data["soil_params_satpsi"] = FloatUnitPair(
-            value=data["geom_mean.psisat_soil_layers_stag=1"],
+            value=x_data,
             unit=METERS,
         )
 
         # this factor (0-1) modifies the gradient of the hydraulic head at the soil bottom. 0=no-flow.
-        self.data["soil_params_slop"] = FloatUnitPair(value=data["mean.slope"], unit=M_PER_M)
+        x_data = data.get("mean.slope",None)
+        if x_data is None: x_data = data.get("slope",None)
+        if x_data is None: raise Exception(f"Neither mean.slope nor slope were found in attributes")        
+        self.data["soil_params_slop"] = FloatUnitPair(value=x_data, unit=M_PER_M)
 
         # saturated soil moisture content
         # NOTE: it seems all values each layer of `smcmax_soil_layers_stag` are the same.
+        x_data = data.get("mean.smcmax_soil_layers_stag=1",None)
+        if x_data is None: x_data = data.get("smcmax_soil_layers_stag=1",None)
+        if x_data is None: raise Exception(f"Neither mean.smcmax_soil_layers_stag=1 nor smcmax_soil_layers_stag=1 were found in attributes")         
         self.data["soil_params_smcmax"] = FloatUnitPair(
-            value=data["mean.smcmax_soil_layers_stag=1"],
+            value=x_data,
             unit=M_PER_M,
         )
 
         # wilting point soil moisture content
         # NOTE: it seems all values each layer of `smcwlt_soil_layers_stag` are the same.
+        x_data = data.get("mean.smcwlt_soil_layers_stag=1=1",None)
+        if x_data is None: x_data = data.get("smcwlt_soil_layers_stag=1",None)
+        if x_data is None: raise Exception(f"Neither mean.smcwlt_soil_layers_stag=1 nor smcwlt_soil_layers_stag=1 were found in attributes")         
         self.data["soil_params_wltsmc"] = FloatUnitPair(
-            value=data["mean.smcwlt_soil_layers_stag=1"],
+            value=x_data,
             unit=M_PER_M,
         )
 
         # maximum storage in the conceptual reservoir
-        self.data["max_gw_storage"] = FloatUnitPair(value=data["mean.Zmax"], unit=METERS)
+        x_data = data.get("mean.Zmax",None)
+        if x_data is None: x_data = data.get("gw_Zmax",None)
+        if x_data is None: raise Exception(f"Neither mean.Zmax nor gw_Zmax were found in attributes")            
+        self.data["max_gw_storage"] = FloatUnitPair(value=x_data, unit=METERS)
 
         # the primary outlet coefficient
-        self.data["cgw"] = FloatUnitPair(value=data["mean.Coeff"], unit=M_PER_H)
+        x_data = data.get("mean.Coeff",None)
+        if x_data is None: x_data = data.get("gw_Coeff",None)
+        if x_data is None: raise Exception(f"Neither mean.Coeff nor gw_Coeff were found in attributes")         
+        self.data["cgw"] = FloatUnitPair(value=x_data, unit=M_PER_H)
 
         # exponent parameter (1.0 for linear reservoir)
-        self.data["expon"] = FloatUnitPair(value=data["mode.Expon"], unit=EMPTY)
+        x_data = data.get("mean.Expon",None)
+        if x_data is None: x_data = data.get("gw_Expon",None)
+        if x_data is None: raise Exception(f"Neither mean.Expon nor gw_Expon were found in attributes")         
+        self.data["expon"] = FloatUnitPair(value=x_data, unit=EMPTY)
 
     def _v2_defaults(self) -> None:
         """

--- a/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
+++ b/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
@@ -56,49 +56,49 @@ class Cfe:
         # beta exponent on Clapp-Hornberger (1978) soil water relations
         # NOTE: it seems all values each layer of `bexp_soil_layers_stag` are the same.
         self.data["soil_params_b"] = FloatUnitPair(
-            value=data["bexp_soil_layers_stag=1"],
+            value=data["mode.bexp_soil_layers_stag=1"],
             unit=EMPTY,
         )
 
         # saturated hydraulic conductivity
         # NOTE: it seems all values each layer of `dksat_soil_layers_stag` are the same.
         self.data["soil_params_satdk"] = FloatUnitPair(
-            value=data["dksat_soil_layers_stag=1"],
+            value=data["geom_mean.dksat_soil_layers_stag=1"],
             unit=M_PER_S,
         )
 
         # saturated capillary head
         # NOTE: it seems all values each layer of `psisat_soil_layers_stag` are the same.
         self.data["soil_params_satpsi"] = FloatUnitPair(
-            value=data["psisat_soil_layers_stag=1"],
+            value=data["geom_mean.psisat_soil_layers_stag=1"],
             unit=METERS,
         )
 
         # this factor (0-1) modifies the gradient of the hydraulic head at the soil bottom. 0=no-flow.
-        self.data["soil_params_slop"] = FloatUnitPair(value=data["slope"], unit=M_PER_M)
+        self.data["soil_params_slop"] = FloatUnitPair(value=data["mean.slope"], unit=M_PER_M)
 
         # saturated soil moisture content
         # NOTE: it seems all values each layer of `smcmax_soil_layers_stag` are the same.
         self.data["soil_params_smcmax"] = FloatUnitPair(
-            value=data["smcmax_soil_layers_stag=1"],
+            value=data["mean.smcmax_soil_layers_stag=1"],
             unit=M_PER_M,
         )
 
         # wilting point soil moisture content
         # NOTE: it seems all values each layer of `smcwlt_soil_layers_stag` are the same.
         self.data["soil_params_wltsmc"] = FloatUnitPair(
-            value=data["smcwlt_soil_layers_stag=1"],
+            value=data["mean.smcwlt_soil_layers_stag=1"],
             unit=M_PER_M,
         )
 
         # maximum storage in the conceptual reservoir
-        self.data["max_gw_storage"] = FloatUnitPair(value=data["gw_Zmax"], unit=METERS)
+        self.data["max_gw_storage"] = FloatUnitPair(value=data["mean.Zmax"], unit=METERS)
 
         # the primary outlet coefficient
-        self.data["cgw"] = FloatUnitPair(value=data["gw_Coeff"], unit=M_PER_H)
+        self.data["cgw"] = FloatUnitPair(value=data["mean.Coeff"], unit=M_PER_H)
 
         # exponent parameter (1.0 for linear reservoir)
-        self.data["expon"] = FloatUnitPair(value=data["gw_Expon"], unit=EMPTY)
+        self.data["expon"] = FloatUnitPair(value=data["mode.Expon"], unit=EMPTY)
 
     def _v2_defaults(self) -> None:
         """

--- a/python/ngen_config_gen/src/ngen/config_gen/models/pet.py
+++ b/python/ngen_config_gen/src/ngen/config_gen/models/pet.py
@@ -47,9 +47,9 @@ class Pet:
         if version != "2.0":
             raise RuntimeError("only support v2 hydrofabric")
 
-        self.data["longitude_degrees"] = data["X"]
-        self.data["latitude_degrees"] = data["Y"]
-        self.data["site_elevation_m"] = data["elevation_mean"]
+        self.data["longitude_degrees"] = data["centroid_x"]
+        self.data["latitude_degrees"] = data["centroid_y"]
+        self.data["site_elevation_m"] = data["mean.elevation"]
 
     def _v2_defaults(self) -> None:
         self.data["yes_wrf"] = False

--- a/python/ngen_config_gen/src/ngen/config_gen/models/pet.py
+++ b/python/ngen_config_gen/src/ngen/config_gen/models/pet.py
@@ -46,10 +46,21 @@ class Pet:
         """
         if version != "2.0":
             raise RuntimeError("only support v2 hydrofabric")
+        
+        x_data = data.get("X",None)
+        if x_data is None: x_data = data.get("centroid_x",None)
+        if x_data is None: raise Exception(f"Neither X nor centroid_x were found in attributes")           
+        self.data["longitude_degrees"] = x_data
 
-        self.data["longitude_degrees"] = data["centroid_x"]
-        self.data["latitude_degrees"] = data["centroid_y"]
-        self.data["site_elevation_m"] = data["mean.elevation"]
+        x_data = data.get("Y",None)
+        if x_data is None: x_data = data.get("centroid_y",None)
+        if x_data is None: raise Exception(f"Neither Y nor centroid_y were found in attributes") 
+        self.data["latitude_degrees"] = x_data
+
+        x_data = data.get("elevation_mean",None)
+        if x_data is None: x_data = data.get("mean.elevation",None)
+        if x_data is None: raise Exception(f"Neither elevation_mean nor mean.elevation were found in attributes") 
+        self.data["site_elevation_m"] = x_data
 
     def _v2_defaults(self) -> None:
         self.data["yes_wrf"] = False


### PR DESCRIPTION
Updates ngen-cal to use the new v2.2 hydrofabric data model. Merging this PR will make ngen-cal incompatible with earlier data model versions. We can add checks to support backwards compatibility if desired. This addresses issue https://github.com/NOAA-OWP/ngen-cal/issues/210.

## Additions
None
-

## Removals
None
-

## Changes
example:
"bexp_soil_layers_stag=1" -> "mode.bexp_soil_layers_stag=1"
-

## Testing

1. 3 tests are failing, but do not appear to be related to these changes

