### PR TITLE
fix: temp solution to allow externally define noah-owp-modular params

### DIFF
--- a/python/ngen_conf/src/ngen/config/noahowp.py
+++ b/python/ngen_conf/src/ngen/config/noahowp.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from .bmi_formulation import BMIFortran
 
 
-class NoahOWPParams(BaseModel):
+class NoahOWPParams(BaseModel, extra='allow'):
     """Class for validating NoahOWP Parameters
     """
     #define params which can be adjusted here


### PR DESCRIPTION
quick workaround so that parameters passed into a noah-owp-modular model persist into the object.